### PR TITLE
NoWhitespaceAfter fix

### DIFF
--- a/checkstyle/configuration/touchin_checkstyle.xml
+++ b/checkstyle/configuration/touchin_checkstyle.xml
@@ -226,7 +226,6 @@
         <module name="NoLineWrap"/>
         <module name="NonEmptyAtclauseDescription"/>
         <module name="NoWhitespaceAfter">
-            <property name="allowLineBreaks" value="false"/>
             <property name="tokens"
                       value="ARRAY_INIT, INC, DEC, UNARY_MINUS, UNARY_PLUS, BNOT, LNOT, DOT, ARRAY_DECLARATOR, INDEX_OP"/>
         </module>


### PR DESCRIPTION
Чтоб можно было определять массивы так:
private static final String[] TRUSTED_CERTS = new String[]{
            "VERY_LONG_STRING1",
            "VERY_LONG_STRING2"
}