### PR TITLE
Base language substitution added

### DIFF
--- a/xcode/aux_scripts/import_strings.php
+++ b/xcode/aux_scripts/import_strings.php
@@ -11,7 +11,7 @@
     $localization = './'.$PROJECT_NAME.'/Resources/Localization/';
 
     $baseFile = file_get_contents(array_pop(glob($COMMON_STRINGS_PATH.'/default*.json')));
-	$baseJson = json_decode($baseFile, true);
+    $baseJson = json_decode($baseFile, true);
 
     foreach (glob($COMMON_STRINGS_PATH.'/*.json') as $file) {
         $languageName = array_pop(explode('_', basename($file, '.json')));

--- a/xcode/aux_scripts/import_strings.php
+++ b/xcode/aux_scripts/import_strings.php
@@ -10,18 +10,21 @@
 
     $localization = './'.$PROJECT_NAME.'/Resources/Localization/';
 
+    $baseFile = file_get_contents(array_pop(glob($COMMON_STRINGS_PATH.'/default*.json')));
+	$baseJson = json_decode($baseFile, true);
+
     foreach (glob($COMMON_STRINGS_PATH.'/*.json') as $file) {
         $languageName = array_pop(explode('_', basename($file, '.json')));
         $isBase = strpos($file, 'default') !== false;
 
         $jsonFile = file_get_contents($file);
-        $json = json_decode($jsonFile);
+        $json = array_merge($baseJson, json_decode($jsonFile, true));
 
         $ios_strings = "";
         foreach ($json as $key=>$value) {
             $ios_strings.='"'.$key.'" = "'.str_replace('%s', '%@', str_replace('"','\"', str_replace("\n", '\n', $value))).'";'.PHP_EOL;
         }
-        $ios_strings = preg_replace('/(\\\\)(u)(\d{4})/', '$1U$3', $ios_strings);
+        $ios_strings = preg_replace('/(\\\\)(u)([0-9a-fA-F]{4})/', '$1U$3', $ios_strings);
 
         $lproj = $localization.$languageName.'.lproj/';
         createFolder($lproj);


### PR DESCRIPTION
Add ability to obtain from this:

```
// default_common_strings_ru.json
{
    "android_global_app_name": "Криптонатор",
    "global_error_general_title": "Что-то пошло не так",
    "global_validation_error_empty_field": "Обязательное поле",
    "global_validation_error_email_is_not_correct": "Неправильный Email",
    "global_word_code": "Код",
    "global_word_email": "Email",
    "global_word_error": "Ошибка",
    "global_word_next": "Далее",
    "global_word_ok": "Ok",
    "global_word_password": "Пароль",
    "global_word_cancel": "Отмена"
}

// common_strings_en.json
{
    "android_global_app_name": "Cryptonator"
}
```

this:

```

// Localizable.string (Russian + Base)
"android_global_app_name" = "Криптонатор";
"global_error_general_title" = "Что-то пошло не так";
"global_validation_error_empty_field" = "Обязательное поле";
"global_validation_error_email_is_not_correct" = "Неправильный Email";
"global_word_code" = "Код";
"global_word_email" = "Email";
"global_word_error" = "Ошибка";
"global_word_next" = "Далее";
"global_word_ok" = "Ok";
"global_word_password" = "Пароль";
"global_word_cancel" = "Отмена";

// Localizable.strings (English)
"android_global_app_name" = "Cryptonator";
"global_error_general_title" = "Что-то пошло не так";
"global_validation_error_empty_field" = "Обязательное поле";
"global_validation_error_email_is_not_correct" = "Неправильный Email";
"global_word_code" = "Код";
"global_word_email" = "Email";
"global_word_error" = "Ошибка";
"global_word_next" = "Далее";
"global_word_ok" = "Ok";
"global_word_password" = "Пароль";
"global_word_cancel" = "Отмена";
```