### PR TITLE
allow inout keyword

### DIFF
--- a/xcode/.swiftlint.yml
+++ b/xcode/.swiftlint.yml
@@ -127,13 +127,6 @@ custom_rules:
     message: "Please use `weak` instead. "
     severity: error
 
-  inout_keyword:
-    name: "Inout"
-    regex: 'inout'
-    message: "Don't use inout arguments"
-    severity: error
-    match_kinds: keyword
-
   continue_keyword:
     name: "Continue"
     regex: 'continue'
@@ -146,6 +139,6 @@ custom_rules:
     regex: '[а-яА-Я]+'
     message: "Localize or translate"
     severity: error
-    match_kinds: 
+    match_kinds:
     - identifier
     - string


### PR DESCRIPTION
```swift
extension String.SubSequence {

    func calculateDistance(to other: String.SubSequence,
                           cache: inout [Set<String.SubSequence>: Int]) -> Int {
        let key = Set([self, other])

        if let result = cache[key] {
            return result
        }

        let result: Int

        if isEmpty || other.isEmpty {
            result = abs(count - other.count)
        } else if first == other.first {
            let tail = self[index(after: startIndex)...]
            let otherTail = other[other.index(after: other.startIndex)...]

            result = tail.calculateDistance(to: otherTail, cache: &cache)
        } else {
            let tail = self[index(after: startIndex)...]
            let otherTail = other[other.index(after: other.startIndex)...]

            let add = calculateDistance(to: otherTail, cache: &cache)
            let replace = tail.calculateDistance(to: otherTail, cache: &cache)
            let delete = tail.calculateDistance(to: other, cache: &cache)

            result = Swift.min(add, replace, delete) + 1
        }

        cache[key] = result

        return result
    }

}

extension String {

    func calculateDistance(to other: String) -> Int {
        var cache: [Set<String.SubSequence>: Int] = [:]

        return Substring(self).calculateDistance(to: Substring(other), cache: &cache)
    }

    var searchString: String {
        return components(separatedBy: .searchStringCharacterSet).joined().lowercased()
    }

}
```