### PR TITLE
Change api generation and localization scripts to work with swift modules

### DIFF
--- a/xcode/aux_scripts/import_strings.php
+++ b/xcode/aux_scripts/import_strings.php
@@ -41,7 +41,7 @@
                                  'extension String {'.PHP_EOL;
             foreach ($json as $key=>$value) {
                 $value_without_linefeed = preg_replace("/\r|\n/", " ", $value);
-                $ios_swift_strings .= "\t/// ".$value_without_linefeed."\n\t".'static let '.preg_replace_callback('/_(.?)/', function ($m) { return strtoupper($m[1]); }, $key).' = NSLocalizedString("'.$key.'", comment: "")'."\n".PHP_EOL;
+                $ios_swift_strings .= "\t/// ".$value_without_linefeed."\n\t".'public static let '.preg_replace_callback('/_(.?)/', function ($m) { return strtoupper($m[1]); }, $key).' = NSLocalizedString("'.$key.'", comment: "")'."\n".PHP_EOL;
             }
             $ios_swift_strings .= '}'.PHP_EOL;
             file_put_contents($localization.'String+Localization.swift', $ios_swift_strings);

--- a/xcode/aux_scripts/import_strings.php
+++ b/xcode/aux_scripts/import_strings.php
@@ -1,5 +1,5 @@
 <?php
-    $PROJECT_NAME = $argv[1];
+    $PRODUCT_NAME = $argv[1];
     $COMMON_STRINGS_PATH = $argv[2];
 
     function createFolder($path) {
@@ -8,7 +8,7 @@
         }
     }
 
-    $localization = './'.$PROJECT_NAME.'/Resources/Localization/';
+    $localization = './'.$PRODUCT_NAME.'/Resources/Localization/';
 
     $baseFile = file_get_contents(array_pop(glob($COMMON_STRINGS_PATH.'/default*.json')));
     $baseJson = json_decode($baseFile, true);

--- a/xcode/build_phases/api_generator.sh
+++ b/xcode/build_phases/api_generator.sh
@@ -6,4 +6,4 @@ link="https://dl.bintray.com/touchin/touchin-tools/ru/touchin/api-generator/${VE
 . build-scripts/xcode/aux_scripts/download_file.sh ${FILE_NAME} ${link}
 
 # execute api generator
-java -jar "Downloads/${FILE_NAME}" generate-client-code --output-language SWIFT --specification-path common/api --output-path ${PROJECT_NAME}/Generated --single-file true
+java -jar "Downloads/${FILE_NAME}" generate-client-code --output-language SWIFT --specification-path common/api --output-path ${PRODUCT_NAME}/Generated --single-file true

--- a/xcode/build_phases/localization.sh
+++ b/xcode/build_phases/localization.sh
@@ -1,4 +1,4 @@
-LOCALIZATION_PATH="${PROJECT_NAME}/Resources/Localization"
+LOCALIZATION_PATH="${PRODUCT_NAME}/Resources/Localization"
 #first argument set strings folder path
 STRINGS_FOLDER=${1:-"common/strings"}
 
@@ -13,4 +13,4 @@ if ! [ -e "${PROJECT_DIR}/${STRINGS_FOLDER}" ]; then
 fi
 
 #second argument set strings script path
-php ${2:-build-scripts/xcode/aux_scripts/import_strings.php} ${PROJECT_NAME} ${STRINGS_FOLDER}
+php ${2:-build-scripts/xcode/aux_scripts/import_strings.php} ${PRODUCT_NAME} ${STRINGS_FOLDER}


### PR DESCRIPTION
С данными изменениями можно использовать скрипты для генерации локализации и API в любом из тагретов. Не ломает текущее использование в основном таргете приложения.