### PR TITLE
New closure style rule

### DIFF
--- a/xcode/.swiftlint.yml
+++ b/xcode/.swiftlint.yml
@@ -229,7 +229,7 @@ custom_rules:
 
   single_line_closure:
     name: "Single line closure"
-    regex: '(\{([^\n]*\[[^\]]+\][^\n]*)?([^\n]*[a-zA-Z]+(, (_|[a-zA-Z]+))*)? in)|(\{[^\n]+ in [^\n]+)'
+    regex: '(\{([^\n]*\[[^\]]+\][^\n]*)?([^\n]*[a-zA-Z]+(, (_|[a-zA-Z]+))*)? in )|(\{[^\n]+ in [^\n]+)'
     message: "Make a new line after `in` keyword in closure"
     severity: error
 

--- a/xcode/.swiftlint.yml
+++ b/xcode/.swiftlint.yml
@@ -229,7 +229,7 @@ custom_rules:
 
   single_line_closure:
     name: "Single line closure"
-    regex: '\{[^\n\/]+ in [^\n\/]+'
+    regex: '\{ \[[^\]]+\] [^\n\/]+ in [^\n\/]+'
     message: "Make a new line after `in` keyword in closure"
     severity: error
 

--- a/xcode/.swiftlint.yml
+++ b/xcode/.swiftlint.yml
@@ -230,7 +230,7 @@ custom_rules:
   single_line_closure:
     name: "Single line closure"
     regex: '\{([^\n]*\[[^\]]+\][^\n]*)?([^\n]*[a-zA-Z]+(, (_|[a-zA-Z]+))*)? in [^\n]+'
-    message: "Make a new line after `in` keyword in closure"
+    message: "Too complex expression for single line closure. Improve readability by making it multiline."
     severity: error
 
   # Rx

--- a/xcode/.swiftlint.yml
+++ b/xcode/.swiftlint.yml
@@ -229,7 +229,7 @@ custom_rules:
 
   single_line_closure:
     name: "Single line closure"
-    regex: '(\{([^\n]*\[[^\]]+\][^\n]*)?([^\n]*[a-zA-Z]+(, (_|[a-zA-Z]+))*)? in )|(\{[^\n]+ in [^\n]+)'
+    regex: '\{([^\n]*\[[^\]]+\][^\n]*)?([^\n]*[a-zA-Z]+(, (_|[a-zA-Z]+))*)? in [^\n]+'
     message: "Make a new line after `in` keyword in closure"
     severity: error
 

--- a/xcode/.swiftlint.yml
+++ b/xcode/.swiftlint.yml
@@ -229,7 +229,7 @@ custom_rules:
 
   single_line_closure:
     name: "Single line closure"
-    regex: '[^\n\/\/]+\{[^\n]+ in [^\n]+'
+    regex: '\{[^\n\/]+ in [^\n\/]+'
     message: "Make a new line after `in` keyword in closure"
     severity: error
 

--- a/xcode/.swiftlint.yml
+++ b/xcode/.swiftlint.yml
@@ -229,7 +229,7 @@ custom_rules:
 
   single_line_closure:
     name: "Single line closure"
-    regex: '\{[^\n]+ in[^\n]+'
+    regex: '\{[^\n]+ in [^\n]+'
     message: "Make a new line after `in` keyword in closure"
     severity: error
 

--- a/xcode/.swiftlint.yml
+++ b/xcode/.swiftlint.yml
@@ -229,7 +229,7 @@ custom_rules:
 
   single_line_closure:
     name: "Single line closure"
-    regex: '\{ \[[^\]]+\] [^\n\/]+ in [^\n\/]+'
+    regex: '(\{([^\n]*\[[^\]]+\][^\n]*)?([^\n]*[a-zA-Z]+(, (_|[a-zA-Z]+))*)? in)|(\{[^\n]+ in [^\n]+)'
     message: "Make a new line after `in` keyword in closure"
     severity: error
 

--- a/xcode/.swiftlint.yml
+++ b/xcode/.swiftlint.yml
@@ -230,7 +230,7 @@ custom_rules:
   single_line_closure:
     name: "Single line closure"
     regex: '\{[^\n]+ in[^\n]+'
-    message: "Make a new line after `in` in closure"
+    message: "Make a new line after `in` keyword in closure"
     severity: error
 
   # Rx

--- a/xcode/.swiftlint.yml
+++ b/xcode/.swiftlint.yml
@@ -227,6 +227,12 @@ custom_rules:
     message: "Returning a boolean as true is redundant, and `!`-syntax is preferred over returning as false."
     severity: error
 
+  single_line_closure:
+    name: "Single line closure"
+    regex: '\{[^\n]+ in[^\n]+'
+    message: "Make a new line after `in` in closure"
+    severity: error
+
   # Rx
 
   unused_map_parameter:

--- a/xcode/.swiftlint.yml
+++ b/xcode/.swiftlint.yml
@@ -229,7 +229,7 @@ custom_rules:
 
   single_line_closure:
     name: "Single line closure"
-    regex: '\{[^\n]+ in [^\n]+'
+    regex: '[^\n\/\/]+\{[^\n]+ in [^\n]+'
     message: "Make a new line after `in` keyword in closure"
     severity: error
 


### PR DESCRIPTION
#181

```

 non-triggered

{ _, _, _ in someFunc() }

{ someFunc() }

{ $0 * 3 }

{ _ in someFunc() }

{  someFunc($0) }

 triggered

{ _, test, _ in someFunc() }

{ test, _, test in someFunc() }

{ test in someFunc() }

{ [weak self] in someFunc() }

{ [weak self] _ in someFunc() }

{ [weak self] test in someFunc() }

{ [someVariable] _ in someFunc() }

{ _, _ -> Bool in someFunc() }

 should be like

{ [weak self] test -> Bool in
    someFunc() 
}
```
Licard ~ 39 ошибок, Ubrd ~ 20. Ложных срабатываний не заметил:/