### PR TITLE
Add string annotation type check rule

### DIFF
--- a/xcode/.swiftlint.yml
+++ b/xcode/.swiftlint.yml
@@ -241,7 +241,7 @@ custom_rules:
 
   redundant_type_annotation_string:
     name: "Redundant type annotation for String"
-    regex: '((var|let)) *\w+ *(((: *String *=)|((\w| |<|>|:)*= *BehaviorRelay<String>\( *value *:)) *((("[^"]+)|([\w]+(\.[\w]+)?)(\s|\n)*\?(\s|\n)*("[^"]+)|([\w]+(\.[\w]+)?)(\s|\n)*:(\s|\n)*("[^"]+)|([\w]+(\.[\w]+)?))|(("[^"]+)|([\w]+(\.[\w]+)?)\s*\?\?\s*("[^"]+)|([\w]+(\.[\w]+)?))|(("[^"]+)|([\w]+(\.[\w]+)?))))|(: *BehaviorRelay<String> *= *BehaviorRelay<String>)'
+    regex: '((var|let)) *\w+ *(((: *String *=)|([^=]*= *BehaviorRelay<String>\( *value *:)) *((("[^"]+)|([\w]+(\.[\w]+)?)(\s|\n)*\?(\s|\n)*("[^"]+)|([\w]+(\.[\w]+)?)(\s|\n)*:(\s|\n)*("[^"]+)|([\w]+(\.[\w]+)?))|(("[^"]+)|([\w]+(\.[\w]+)?)\s*\?\?\s*("[^"]+)|([\w]+(\.[\w]+)?))|(("[^"]+)|([\w]+(\.[\w]+)?))))|(: *BehaviorRelay<String> *= *BehaviorRelay<String>)'
     message: "Using a type annotation for String is redundant"
     severity: error
 

--- a/xcode/.swiftlint.yml
+++ b/xcode/.swiftlint.yml
@@ -241,7 +241,7 @@ custom_rules:
 
   redundant_type_annotation_string:
     name: "Redundant type annotation for String"
-    regex: '((var|let)) *\w+ *((: *String *=)|((\w| |<|>|:)*= *BehaviorRelay<String>\( *value *:)) *((\w+\.)|")?\w+'
+    regex: '((var|let)) *\w+ *((: *String *=)|((\w| |<|>|:)*= *BehaviorRelay<String>\( *value *:)) *((["\w]+\.?["\w]+(\s|\n)*\?(\s|\n)*["\w]+\.?["\w]+(\s|\n)*:(\s|\n)*["\w]+\.?["\w]+)|(["\w]+\.?["\w]+\s*\?\?\s*["\w]+\.?["\w]+)|(["\w]+\.?["\w]+[\n\)]))'
     message: "Using a type annotation for String is redundant"
     severity: error
 

--- a/xcode/.swiftlint.yml
+++ b/xcode/.swiftlint.yml
@@ -241,7 +241,7 @@ custom_rules:
 
   redundant_type_annotation_string:
     name: "Redundant type annotation for String"
-    regex: '((var|let)) *\w+ *((: *String *=)|((\w| |<|>|:)*= *BehaviorRelay<String>\( *value *:)) *((["\w]+\.?["\w]+(\s|\n)*\?(\s|\n)*["\w]+\.?["\w]+(\s|\n)*:(\s|\n)*["\w]+\.?["\w]+)|(["\w]+\.?["\w]+\s*\?\?\s*["\w]+\.?["\w]+)|(["\w]+\.?["\w]+[\n\)]))'
+    regex: '((var|let)) *\w+ *(((: *String *=)|((\w| |<|>|:)*= *BehaviorRelay<String>\( *value *:)) *((("[^"]+)|([\w]+(\.[\w]+)?)(\s|\n)*\?(\s|\n)*("[^"]+)|([\w]+(\.[\w]+)?)(\s|\n)*:(\s|\n)*("[^"]+)|([\w]+(\.[\w]+)?))|(("[^"]+)|([\w]+(\.[\w]+)?)\s*\?\?\s*("[^"]+)|([\w]+(\.[\w]+)?))|(("[^"]+)|([\w]+(\.[\w]+)?))))|(: *BehaviorRelay<String> *= *BehaviorRelay<String>)'
     message: "Using a type annotation for String is redundant"
     severity: error
 

--- a/xcode/.swiftlint.yml
+++ b/xcode/.swiftlint.yml
@@ -239,6 +239,12 @@ custom_rules:
     message: "Use сontentView instead of self for addSubview or addSubviews methods in cell."
     severity: error
 
+  redundant_type_annotation_string:
+    name: "Redundant type annotation for String"
+    regex: '((var|let)) *\w+ *((: *String *=)|((\w| |<|>|:)*= *BehaviorRelay<String>\( *value *:)) *\W?\w+'
+    message: "Using a type annotation for String is redundant"
+    severity: error
+
   # Rx
 
   unused_map_parameter:

--- a/xcode/.swiftlint.yml
+++ b/xcode/.swiftlint.yml
@@ -241,7 +241,7 @@ custom_rules:
 
   redundant_type_annotation_string:
     name: "Redundant type annotation for String"
-    regex: '((var|let)) *\w+ *((: *String *=)|((\w| |<|>|:)*= *BehaviorRelay<String>\( *value *:)) *\W?\w+'
+    regex: '((var|let)) *\w+ *((: *String *=)|((\w| |<|>|:)*= *BehaviorRelay<String>\( *value *:)) *((\w+\.)|")?\w+'
     message: "Using a type annotation for String is redundant"
     severity: error
 


### PR DESCRIPTION
аналогично #179 
```
triggered
private let validRelay = BehaviorRelay<String>(value: "test")
private let validRelay = BehaviorRelay<String>(value: .empty)
private let validRelay: BehaviorRelay<String> = BehaviorRelay<String>(value: "test")
private let validRelay: BehaviorRelay<String> = BehaviorRelay<String>(value: .empty)

private let validRelay: String = "test"
private let validRelay: String = .hello
private let validRelay: String = String.hello

non

private let validRelay = BehaviorRelay(value: "test")
private let validRelay = BehaviorRelay(value: .empty)
private let validRelay: BehaviorRelay<String> = BehaviorRelay(value: "test")
private let validRelay: BehaviorRelay<String> = BehaviorRelay(value: .empty)

private let validRelay = "test"
private let validRelay = .hello
private let validRelay = String.hello
```
Licard ~ , Убрир ~ 