### PR TITLE
Include numbers in build badge

### DIFF
--- a/xcode/commonFastfile
+++ b/xcode/commonFastfile
@@ -87,7 +87,10 @@ end
 
 private_lane :addShield do |options|
   buildNumber = options[:buildNumber]
-  buildDescription = options[:xcconfig_name].scan(/\p{Upper}/)[1..2].join
+  buildDescription = options[:xcconfig_name]
+    .split(/(?=[A-Z])/)
+    .map { |v| v.gsub(/[[:lower:]]+/, "") }[1..2]
+    .join
   
   begin
     add_badge(

--- a/xcode/commonFastfile
+++ b/xcode/commonFastfile
@@ -87,10 +87,10 @@ end
 
 private_lane :addShield do |options|
   buildNumber = options[:buildNumber]
-  buildDescription = options[:xcconfig_name]
-    .split(/(?=[A-Z])/)
-    .map { |v| v.gsub(/[[:lower:]]+/, "") }[1..2]
-    .join
+  buildDescription = options[:xcconfig_name] # EnterpriseCustomerDev1WithoutSSLPinningRelease
+    .split(/(?=[A-Z])/) # -> ["Enterprise", "Customer", "Dev1", "Without", "S", "S", "L", "Pinning", "Release"]
+    .map { |v| v.gsub(/[[:lower:]]+/, "") }[1..2] # -> ["E", "C", "D1", "W", "S", "S", "L", "P", "R"] -> ["C", "D1"]
+    .join # -> "CD1"
   
   begin
     add_badge(


### PR DESCRIPTION
Badge на иконке приложения теперь может содержать еще и цифры, если они есть в названии lane

```ruby
{
  "EnterpriseCustomerDev1WithoutSSLPinningRelease" => "CD1",
  "StandardTouchin3MockWithoutSSLPinningRelease" => "T3M",
  "Standard1Touchin4Mock21Without6SSLPinningRelease" => "T4M21",
  "StandardTouchin98765MockWithoutSSLPinningRelease" => "T98765M",
  "StandardTouchinMock321WithoutSSLPinningRelease" => "TM321",
}
```