### PR TITLE
Increment build number without agvtool

### DIFF
--- a/xcode/commonFastfile
+++ b/xcode/commonFastfile
@@ -191,7 +191,7 @@ private_lane :buildArchive do |options|
 end
 
 lane :CreatePushCertificate do |options|
-  configuration = get_configuration_for_type(options[:type] || "development")
+  configuration = get_configuration_for_type(options[:type] || "development", options)
   options = configuration.to_options.merge(options)
 
   certificates_path = File.expand_path "../Certificates"
@@ -220,7 +220,7 @@ lane :SyncCodeSigning do |options|
 end
 
 lane :SyncSymbols do |options|
-  configuration = get_configuration_for_type(options[:type])
+  configuration = get_configuration_for_type(options[:type], options)
   options = configuration.to_options.merge(options)
 
   appName = options[:appName] || $appName
@@ -360,7 +360,7 @@ def sync_code_signing_using_options(options)
 end
 
 def fill_up_options_using_configuration_type(options, configuration_type)
-  configuration = get_configuration_for_type(configuration_type.type)
+  configuration = get_configuration_for_type(configuration_type.type, options)
 
   configuration.to_options
     .merge(get_keychain_options(options))
@@ -384,8 +384,12 @@ def get_keychain_options(options)
   return {:keychain_name => keychain_name, :keychain_password => keychain_password}
 end
 
-def get_configuration_for_type(type)
-  config_path = File.expand_path "configurations.yaml"
+def get_configuration_for_type(type, options)
+  appName = options[:appName] || $appName
+  
+  project_config_path = "configurations_#{appName}.yaml"
+  relative_config_path = File.exists? project_config_path ? project_config_path : "configurations.yaml"
+  config_path = File.expand_path relative_config_path
 
   configuration = Touchlane::Configuration.from_file(config_path, type)
 end

--- a/xcode/commonFastfile
+++ b/xcode/commonFastfile
@@ -118,7 +118,8 @@ private_lane :buildConfiguration do |options|
   if is_ci
     increment_build_number_in_xcodeproj(
       build_number: options[:buildNumber],
-      xcodeproj: "./#{appName}.xcodeproj"
+      xcodeproj: "./#{appName}.xcodeproj",
+      target: "#{appName}"
     )
   end
 

--- a/xcode/commonFastfile
+++ b/xcode/commonFastfile
@@ -388,7 +388,7 @@ def get_configuration_for_type(type, options)
   appName = options[:appName] || $appName
   
   project_config_path = "configurations_#{appName}.yaml"
-  relative_config_path = File.exists? project_config_path ? project_config_path : "configurations.yaml"
+  relative_config_path = File.exists?(project_config_path) ? project_config_path : "configurations.yaml"
   config_path = File.expand_path relative_config_path
 
   configuration = Touchlane::Configuration.from_file(config_path, type)

--- a/xcode/commonFastfile
+++ b/xcode/commonFastfile
@@ -116,8 +116,9 @@ private_lane :buildConfiguration do |options|
   openKeychain(options)
 
   if is_ci
-    increment_build_number(
-      build_number: options[:buildNumber]
+    increment_build_number_in_xcodeproj(
+      build_number: options[:buildNumber],
+      xcodeproj: "./#{appName}.xcodeproj"
     )
   end
 


### PR DESCRIPTION
* Increment build number without agvtool. In order for this to work, fastlane plugin 'versioning' must be installed: `bundle exec fastlane add_plugin versioning`
* Use separate match configurations in a single repo (e.g. `configurations_Ubrd.yaml`, `configurations_VUZBank.yaml`)