### PR TITLE
Add resources to exclude

### DIFF
--- a/xcode/.swiftlint.yml
+++ b/xcode/.swiftlint.yml
@@ -77,6 +77,7 @@ excluded:
   - Pods
   - Generated
   - "**/Generated"
+  - "**/Resources"
 
 line_length:
   warning: 128


### PR DESCRIPTION
Затрагивается только внутрення папка Resources, а не сам таргет. Обычно там лежат файлы, которые сгенерированы и проверять их нет смысла