### PR TITLE
Add code generation phase to ci

### DIFF
--- a/xcode/commonFastfile
+++ b/xcode/commonFastfile
@@ -89,12 +89,12 @@ private_lane :buildConfiguration do |options|
   configuration_type = Touchlane::ConfigurationType.from_lane_name(lane_name)
   options = fill_up_options_using_configuration_type(options, configuration_type)
 
-  #openKeychain(options)
+  openKeychain(options)
 
   if !options[:buildNumber].nil?
-    #increment_build_number(
-     # build_number: options[:buildNumber]
-    #)
+    increment_build_number(
+      build_number: options[:buildNumber]
+    )
   end
 
   ipa_name = "#{appName}.ipa"
@@ -106,7 +106,7 @@ private_lane :buildConfiguration do |options|
   options[:xcodeproj_path] = "../#{appName}.xcodeproj"
   options[:workspace] = "./#{appName}.xcworkspace"
 
-  #installDependencies(options)
+  installDependencies(options)
 
   run_code_generation_phase_if_needed(options)
   generate_enabled_features_extension_if_needed(options)

--- a/xcode/commonFastfile
+++ b/xcode/commonFastfile
@@ -433,9 +433,7 @@ def run_code_generation_phase_if_needed(options)
   code_generation_script_path = File.expand_path "../.githooks/scripts/CodeGen.sh"
   xcodeproj_path = File.expand_path options[:xcodeproj_path]
 
-
   if File.exists? code_generation_script_path
     sh(code_generation_script_path, xcodeproj_path)
   end
-
 end

--- a/xcode/commonFastfile
+++ b/xcode/commonFastfile
@@ -429,11 +429,12 @@ end
 
 # Build phases
 
-def run_code_generation_phase_if_needed()
+def run_code_generation_phase_if_needed(options)
   code_generation_script_path = File.expand_path "../.githooks/scripts/CodeGen.sh"
+  xcodeproj_path = File.expand_path options[:xcodeproj_path]
 
   if File.exists? code_generation_script_path
-    sh(code_generation_script_path)
+    sh("code_generation_script_path ${xcodeproj_path}")
   end
 
 end

--- a/xcode/commonFastfile
+++ b/xcode/commonFastfile
@@ -108,6 +108,7 @@ private_lane :buildConfiguration do |options|
 
   installDependencies(options)
 
+  run_code_generation_phase_if_needed()
   generate_enabled_features_extension_if_needed(options)
 
   if !(options[:uploadToFabric] || options[:uploadToAppStore])
@@ -424,4 +425,15 @@ def set_xcconfig_for_configuration_of_project(lane_name, configuration, xcodepro
 
 
   project.save()
+end
+
+# Build phases
+
+def run_code_generation_phase_if_needed()
+  code_generation_script_path = File.expand_path "../.githooks/scripts/CodeGen.sh"
+
+  if File.exists? code_generation_script_path
+    sh(code_generation_script_path)
+  end
+
 end

--- a/xcode/commonFastfile
+++ b/xcode/commonFastfile
@@ -434,7 +434,7 @@ def run_code_generation_phase_if_needed(options)
   xcodeproj_path = File.expand_path options[:xcodeproj_path]
 
   if File.exists? code_generation_script_path
-    sh("code_generation_script_path ${xcodeproj_path}")
+    sh("#{code_generation_script_path} #{xcodeproj_path}")
   end
 
 end

--- a/xcode/commonFastfile
+++ b/xcode/commonFastfile
@@ -89,12 +89,12 @@ private_lane :buildConfiguration do |options|
   configuration_type = Touchlane::ConfigurationType.from_lane_name(lane_name)
   options = fill_up_options_using_configuration_type(options, configuration_type)
 
-  openKeychain(options)
+  #openKeychain(options)
 
   if !options[:buildNumber].nil?
-    increment_build_number(
-      build_number: options[:buildNumber]
-    )
+    #increment_build_number(
+     # build_number: options[:buildNumber]
+    #)
   end
 
   ipa_name = "#{appName}.ipa"
@@ -106,9 +106,9 @@ private_lane :buildConfiguration do |options|
   options[:xcodeproj_path] = "../#{appName}.xcodeproj"
   options[:workspace] = "./#{appName}.xcworkspace"
 
-  installDependencies(options)
+  #installDependencies(options)
 
-  run_code_generation_phase_if_needed()
+  run_code_generation_phase_if_needed(options)
   generate_enabled_features_extension_if_needed(options)
 
   if !(options[:uploadToFabric] || options[:uploadToAppStore])
@@ -433,8 +433,9 @@ def run_code_generation_phase_if_needed(options)
   code_generation_script_path = File.expand_path "../.githooks/scripts/CodeGen.sh"
   xcodeproj_path = File.expand_path options[:xcodeproj_path]
 
+
   if File.exists? code_generation_script_path
-    sh("#{code_generation_script_path} #{xcodeproj_path}")
+    sh(code_generation_script_path, xcodeproj_path)
   end
 
 end


### PR DESCRIPTION
Идея заключается в том, что необходимость запуска скриптов должна регулироваться не Xcod'ом, а теми сущностями, которым это необходимо.

Кроме того, вынес все скрипты в отдельные файлы, так как ожидается их переезд в Build-scripts, в случае если эксперимент на Убрире окажется удачным. 

Пока отсутствие файла в конкретной папке считается за старые билд фазы 

<img width="860" alt="Screenshot 2021-03-23 at 17 59 30" src="https://user-images.githubusercontent.com/31570429/112167503-8dfdab80-8c01-11eb-9477-9bb37de7b1ad.png">