### PR TITLE
Feature - move to workspace

### DIFF
--- a/xcode/commonFastfile
+++ b/xcode/commonFastfile
@@ -108,7 +108,7 @@ private_lane :buildConfiguration do |options|
 
   installDependencies(options)
 
-  run_code_generation_phase_if_needed(options)
+  run_code_generation_phase_if_needed()
   generate_enabled_features_extension_if_needed(options)
 
   if !(options[:uploadToFabric] || options[:uploadToAppStore])
@@ -438,9 +438,9 @@ end
 
 # Build phases
 
-def run_code_generation_phase_if_needed(options)
+def run_code_generation_phase_if_needed:
   code_generation_script_path = File.expand_path "../.githooks/scripts/CodeGen.sh"
-  workspace_path = File.expand_path options[:workspace]
+  workspace_path = File.expand_path "../#{appName}.xcworkspace"
 
   if File.exists? code_generation_script_path
     sh(code_generation_script_path, workspace_path)

--- a/xcode/commonFastfile
+++ b/xcode/commonFastfile
@@ -438,7 +438,7 @@ end
 
 # Build phases
 
-def run_code_generation_phase_if_needed:
+def run_code_generation_phase_if_needed()
   code_generation_script_path = File.expand_path "../.githooks/scripts/CodeGen.sh"
   workspace_path = File.expand_path "../#{appName}.xcworkspace"
 

--- a/xcode/commonFastfile
+++ b/xcode/commonFastfile
@@ -108,7 +108,7 @@ private_lane :buildConfiguration do |options|
 
   installDependencies(options)
 
-  run_code_generation_phase_if_needed()
+  run_code_generation_phase_if_needed(options)
   generate_enabled_features_extension_if_needed(options)
 
   if !(options[:uploadToFabric] || options[:uploadToAppStore])
@@ -438,7 +438,8 @@ end
 
 # Build phases
 
-def run_code_generation_phase_if_needed()
+def run_code_generation_phase_if_needed(options)
+  appName = options[:appName] || $appName
   code_generation_script_path = File.expand_path "../.githooks/scripts/CodeGen.sh"
   workspace_path = File.expand_path "../#{appName}.xcworkspace"
 

--- a/xcode/commonFastfile
+++ b/xcode/commonFastfile
@@ -440,9 +440,9 @@ end
 
 def run_code_generation_phase_if_needed(options)
   code_generation_script_path = File.expand_path "../.githooks/scripts/CodeGen.sh"
-  xcodeproj_path = File.expand_path options[:xcodeproj_path]
+  workspace_path = File.expand_path options[:workspace]
 
   if File.exists? code_generation_script_path
-    sh(code_generation_script_path, xcodeproj_path)
+    sh(code_generation_script_path, workspace_path)
   end
 end


### PR DESCRIPTION
По странным обстоятельствам xcodebuild не может разрешить версионирование для spm пакетов, если они зависят от бинарников локально. Одно из решений данной проблемы - использование workspace вместо project - [подробнее](https://developer.apple.com/forums/thread/668331)

Как локально, так и на билдере всё работает корректно