### PR TITLE
feat: skip_app_version_update

### DIFF
--- a/xcode/commonFastfile
+++ b/xcode/commonFastfile
@@ -55,6 +55,8 @@ def upload_to_app_store_using_options(options)
     ipa: options[:ipa_path],
     force: true, # skip metainfo prompt
     skip_metadata: true,
+    skip_app_version_update: options[:skip_app_version_update],
+    skip_screenshots: options[:skip_screenshots],
     team_id: options[:itc_team_id],
     dev_portal_team_id: options[:team_id],
     precheck_include_in_app_purchases: false
@@ -130,6 +132,9 @@ private_lane :buildConfiguration do |options|
   if options[:uploadToAppStore]
     options[:compileBitcode] = options[:compileBitcode].nil? ? true : options[:compileBitcode]
     options[:include_symbols] = options[:include_symbols].nil? ? true : options[:include_symbols]
+
+    options[:skip_app_version_update] = options[:skipAppVersionUpdate].nil? ? false : options[:skipAppVersionUpdate]
+    options[:skip_screenshots] = options[:skipAppVersionUpdate].nil? ? false : options[:skipAppVersionUpdate]
 
     sync_code_signing_using_options(options)
 


### PR DESCRIPTION
Если сборка в App Store находится на ревью и нужно загрузить новую или необходимо загрузить разные версии приложения, но при этом не трогая текущий релиз, полезно будет выбрать параметр - skip_app_version_update.

По факту мы пропускаем все этапы, которые как либо затрагивают обновление страницы релиза в App Store.
<img width="697" alt="Screenshot 2021-06-08 at 09 24 49" src="https://user-images.githubusercontent.com/31570429/121133798-71096980-c83b-11eb-8e14-d04151b79d3a.png">
