### PR TITLE
Feature/firebase separation

### DIFF
--- a/xcode/commonFastfile
+++ b/xcode/commonFastfile
@@ -237,7 +237,7 @@ private_lane :openKeychain do |options|
       name: options[:keychain_name],
       password: options[:keychain_password],
       unlock: true,
-      timeout: 0,
+      timeout: false,
       add_to_search_list: !keychain_exists
     )
   else

--- a/xcode/commonFastfile
+++ b/xcode/commonFastfile
@@ -237,7 +237,7 @@ private_lane :openKeychain do |options|
       name: options[:keychain_name],
       password: options[:keychain_password],
       unlock: true,
-      timeout: false,
+      timeout: 0,
       add_to_search_list: !keychain_exists
     )
   else

--- a/xcode/commonFastfile
+++ b/xcode/commonFastfile
@@ -379,7 +379,7 @@ def get_configuration_for_type(type)
 end
 
 def get_google_services_plist_path(app_target_folder_name, configuration_type)
-  File.expand_path "../#{app_target_folder_name}/Resources/#{configuration_type.prefix}-GoogleService-Info.plist"
+  File.expand_path "../#{app_target_folder_name}/Resources/GoogleService-Info.plist"
 end
 
 def generate_enabled_features_extension_if_needed(options)


### PR DESCRIPTION
Задача: Разделение firebase. В зависимости от конфигурации оставлять один GoogleService-Info.plist, что дает возможность использовать разные проекты.