### PR TITLE
Update .swiftlint.yml

### DIFF
--- a/xcode/.swiftlint.yml
+++ b/xcode/.swiftlint.yml
@@ -268,7 +268,7 @@ custom_rules:
   lazy_var:
     name: "Lazy var access modifier"
     regex: '(?<!private\(set\)\s)lazy\s+var'
-    message: "Lazy var can use only with private(set) modifier."
+    message: "Lazy var can only be used with private(set) modifier."
     severity: warning
 
   # Rx

--- a/xcode/.swiftlint.yml
+++ b/xcode/.swiftlint.yml
@@ -266,9 +266,9 @@ custom_rules:
     severity: warning
     
   lazy_var:
-    name: "Using lazy var"
+    name: "Lazy var access modifier"
     regex: '(?<!private\(set\)\s)lazy\s+var'
-    message: "Use lazy var can only with private(set) modifier"
+    message: "Lazy var can use only with private(set) modifier."
     severity: warning
 
   # Rx

--- a/xcode/.swiftlint.yml
+++ b/xcode/.swiftlint.yml
@@ -264,6 +264,12 @@ custom_rules:
     regex: 'case[^\n\(]+\([^\)]*(let|var)\s'
     message: "Use a let|var keyword behind parentheses"
     severity: warning
+    
+  lazy_var:
+    name: "Using lazy var"
+    regex: '(?<!private\(set\)\s)lazy\s+var'
+    message: "Use lazy var can only with private(set) modifier"
+    severity: warning
 
   # Rx
 


### PR DESCRIPTION
В подавляющем большинстве случаев lazy var можно заменить на computed var или let с инициализацией в момент конструирования инстанса, но есть редкие случаи когда lazy var нужен, поэтому совсем запретить lazy var нельзя.

https://github.com/TouchInstinct/BuildScripts/issues/267