### PR TITLE
add install_env script for build phases

### DIFF
--- a/xcode/aux_scripts/install_env.sh
+++ b/xcode/aux_scripts/install_env.sh
@@ -1,0 +1,13 @@
+# When you run Git from the command line, it runs in the environment as set up by your Shell. 
+# GUI OS X apps, however, have no knowledge about your shell - and the PATH environment can be changed in many different places.
+# Export our profile with path by ourselves
+
+function source_home_file {
+  file="$HOME/$1"
+  [[ -f "${file}" ]] && source "${file}"
+}
+
+# Use specific exec due to Xcode has custom value of $PATH 
+if [ -z "$(which pmd)" ]; then	
+   source_home_file ".bash_profile" || source_home_file ".zshrc" || true
+fi


### PR DESCRIPTION
Vlad Suhomlinov, [30 Apr 2021, 11:56:13]:

Все те переменные окружения, которые вы вставляете, при использовании xcodebuild он затирает

поэтому, чтобы всё работало, необходимо в кажду билдфазу если это того требуется добавлять свои переменные окружения