### PR TITLE
feat: lint only changed files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# macOS
+
+.DS_Store

--- a/xcode/.swiftlint.yml
+++ b/xcode/.swiftlint.yml
@@ -115,6 +115,8 @@ identifier_name:
 
 warning_threshold: 1
 
+allow_zero_lintable_files: true
+
 custom_rules:
 
   # General

--- a/xcode/build_phases/swiftlint.sh
+++ b/xcode/build_phases/swiftlint.sh
@@ -12,14 +12,19 @@
 #   SRCROOT - project directory.
 #   PODS_ROOT - cocoapods installation directory (eg. ${SRCROOT}/Pods).
 #
+# Available environment variables:
+#   FORCE_LINT - lint all project.
+#
 # Optional environment variables:
 #   SWIFTLINT_EXECUTABLE - path to swiftlint executable.
 #   SWIFTLINT_CONFIG_PATH - path to swiftlint config.
 #   SCRIPT_INPUT_FILE_COUNT - number of files listed in "Input files" of build phase.
 #   SCRIPT_INPUT_FILE_{N} - file path to directory that should be checked.
+#   FORCE_LINT - lint all project.
 #
 # Example of usage:
 #   swiftlint.sh
+#   FORCE_LINT=true; swiftlint.sh
 #   swiftlint.sh Pods/Swiftlint/swiftlint build-scripts/xcode/.swiftlint.yml
 #
 
@@ -41,37 +46,45 @@ if [ -z "${SWIFTLINT_CONFIG_PATH}" ]; then
     fi
 fi
 
-# Xcode упадет, если будем использовать большое количество Script Input Files, 
-# так как просто переполнится стек - https://unix.stackexchange.com/questions/357843/setting-a-long-environment-variable-breaks-a-lot-of-commands
-# Поэтому воспользуемся "скрытым" параметром Swiflint - https://github.com/realm/SwiftLint/pull/3313
-# Создадим временный файл swiftlint_files с префиксом @ и в нем уже определим список файлов
-# необходимых для линтовки :)
+if [ ! -z "${FORCE_LINT}" ]; then
+    # Если задана переменная FORCE_LINT, то проверяем все файлы проекта
+    for SOURCE_DIR in ${SOURCES_DIRS}; do
+        ${SWIFTLINT_EXECUTABLE} autocorrect --path ${SOURCE_DIR} --config ${SWIFTLINT_CONFIG_PATH}
+        ${SWIFTLINT_EXECUTABLE} --path ${SOURCE_DIR} --config ${SWIFTLINT_CONFIG_PATH}
+    done
+else 
+    # Xcode упадет, если будем использовать большое количество Script Input Files, 
+    # так как просто переполнится стек - https://unix.stackexchange.com/questions/357843/setting-a-long-environment-variable-breaks-a-lot-of-commands
+    # Поэтому воспользуемся "скрытым" параметром Swiflint - https://github.com/realm/SwiftLint/pull/3313
+    # Создадим временный файл swiftlint_files с префиксом @ и в нем уже определим список файлов
+    # необходимых для линтовки :)
 
-lint_files_path="${SRCROOT}/build_phases/swiftlint_files"
+    lint_files_path="${SRCROOT}/build_phases/swiftlint_files"
 
-if [ ! -z "${lint_files_path}" ]; then
-    > ${lint_files_path} # Если файл существует, то просто его очистим
-else
-    touch ${lint_files_path} # Если файла нет, то создадим его
+    if [ ! -z "${lint_files_path}" ]; then
+        > ${lint_files_path} # Если файл существует, то просто его очистим
+    else
+        touch ${lint_files_path} # Если файла нет, то создадим его
+    fi
+
+    # Проходимся по папкам, которые требуют линтовки
+    for SOURCE_DIR in ${SOURCES_DIRS}; do
+
+        # Отбираем файлы, которые были изменены или созданы
+        source_unstaged_files=$(git diff --diff-filter=d --name-only ${SOURCE_DIR} | grep "\.swift$")
+        source_staged_files=$(git diff --diff-filter=d --name-only --cached ${SOURCE_DIR} | grep "\.swift$")
+
+        if [ ! -z "${source_unstaged_files}" ]; then
+            echo "${source_unstaged_files}" >> ${lint_files_path}
+        fi
+
+        if [ ! -z "${source_staged_files}" ]; then
+            echo "${source_staged_files}" >> ${lint_files_path}
+        fi
+    done
+
+    swiftlint_files_path="@${lint_files_path}"
+
+    ${SWIFTLINT_EXECUTABLE} autocorrect --path ${swiftlint_files_path} --config ${SWIFTLINT_CONFIG_PATH} --force-exclude --use-alternative-excluding
+    ${SWIFTLINT_EXECUTABLE} --path ${swiftlint_files_path} --config ${SWIFTLINT_CONFIG_PATH} --force-exclude --use-alternative-excluding
 fi
-
-# Проходимся по папкам, которые требуют линтовки
-for SOURCE_DIR in ${SOURCES_DIRS}; do
-
-    # Отбираем файлы, которые были изменены или созданы
-    source_unstaged_files=$(git diff --diff-filter=d --name-only ${SOURCE_DIR} | grep "\.swift$")
-    source_staged_files=$(git diff --diff-filter=d --name-only --cached ${SOURCE_DIR} | grep "\.swift$")
-
-    if [ ! -z "${source_unstaged_files}" ]; then
-        echo "${source_unstaged_files}" >> ${lint_files_path}
-    fi
-
-    if [ ! -z "${source_staged_files}" ]; then
-        echo "${source_staged_files}" >> ${lint_files_path}
-    fi
-done
-
-swiftlint_files_path="@${lint_files_path}"
-
-${SWIFTLINT_EXECUTABLE} autocorrect --path ${swiftlint_files_path} --config ${SWIFTLINT_CONFIG_PATH} --force-exclude --use-alternative-excluding
-${SWIFTLINT_EXECUTABLE} lint --path ${swiftlint_files_path} --config ${SWIFTLINT_CONFIG_PATH} --force-exclude --use-alternative-excluding

--- a/xcode/build_phases/swiftlint.sh
+++ b/xcode/build_phases/swiftlint.sh
@@ -73,5 +73,5 @@ done
 
 swiftlint_files_path="@${lint_files_path}"
 
-${SWIFTLINT_EXECUTABLE} autocorrect --path ${swiftlint_files_path} --config ${SWIFTLINT_CONFIG_PATH}
-${SWIFTLINT_EXECUTABLE} lint --path ${swiftlint_files_path} --config ${SWIFTLINT_CONFIG_PATH}
+${SWIFTLINT_EXECUTABLE} autocorrect --path ${swiftlint_files_path} --config ${SWIFTLINT_CONFIG_PATH} --force-exclude
+${SWIFTLINT_EXECUTABLE} lint --path ${swiftlint_files_path} --config ${SWIFTLINT_CONFIG_PATH} --force-exclude

--- a/xcode/build_phases/swiftlint.sh
+++ b/xcode/build_phases/swiftlint.sh
@@ -73,5 +73,5 @@ done
 
 swiftlint_files_path="@${lint_files_path}"
 
-${SWIFTLINT_EXECUTABLE} autocorrect --path ${swiftlint_files_path} --config ${SWIFTLINT_CONFIG_PATH} --force-exclude
-${SWIFTLINT_EXECUTABLE} lint --path ${swiftlint_files_path} --config ${SWIFTLINT_CONFIG_PATH} --force-exclude
+${SWIFTLINT_EXECUTABLE} autocorrect --path ${swiftlint_files_path} --config ${SWIFTLINT_CONFIG_PATH} --force-exclude --use-alternative-excluding
+${SWIFTLINT_EXECUTABLE} lint --path ${swiftlint_files_path} --config ${SWIFTLINT_CONFIG_PATH} --force-exclude --use-alternative-excluding

--- a/xcode/build_phases/swiftlint.sh
+++ b/xcode/build_phases/swiftlint.sh
@@ -12,9 +12,6 @@
 #   SRCROOT - project directory.
 #   PODS_ROOT - cocoapods installation directory (eg. ${SRCROOT}/Pods).
 #
-# Available environment variables:
-#   FORCE_LINT - lint all project.
-#
 # Optional environment variables:
 #   SWIFTLINT_EXECUTABLE - path to swiftlint executable.
 #   SWIFTLINT_CONFIG_PATH - path to swiftlint config.

--- a/xcode/build_phases/swiftlint.sh
+++ b/xcode/build_phases/swiftlint.sh
@@ -61,11 +61,8 @@ else
 
     lint_files_path="${SRCROOT}/build_phases/swiftlint_files"
 
-    if [ ! -z "${lint_files_path}" ]; then
-        > ${lint_files_path} # Если файл существует, то просто его очистим
-    else
-        touch ${lint_files_path} # Если файла нет, то создадим его
-    fi
+    # Если файл существует, то просто его очистим, если нет - создадим
+    > ${lint_files_path}
 
     # Проходимся по папкам, которые требуют линтовки
     for SOURCE_DIR in ${SOURCES_DIRS}; do

--- a/xcode/build_phases/swiftlint.sh
+++ b/xcode/build_phases/swiftlint.sh
@@ -50,7 +50,7 @@ fi
 lint_files_path="${SRCROOT}/build_phases/swiftlint_files"
 
 if [ ! -z "${lint_files_path}" ]; then
-    > ${lint_files_path} # Если файл существует, то просто его отчистим
+    > ${lint_files_path} # Если файл существует, то просто его очистим
 else
     touch ${lint_files_path} # Если файла нет, то создадим его
 fi

--- a/xcode/commonFastfile
+++ b/xcode/commonFastfile
@@ -148,7 +148,6 @@ private_lane :buildArchive do |options|
   lane_name = options[:lane_name]
   configuration = options[:configuration]
   xcodeproj_path = options[:xcodeproj_path]
-  xcargs = "FORCE_LINT='true'" # To enable linting on project without CodeLint target
 
   if configuration != "AppStore" # AppStore uses xcconfig choosen in Xcode
     set_xcconfig_for_configuration_of_project(lane_name, configuration, xcodeproj_path)
@@ -167,7 +166,6 @@ private_lane :buildArchive do |options|
     skip_package_ipa: options[:skip_package_ipa],
     include_symbols: options[:include_symbols] || false,
     include_bitcode: options[:compileBitcode] || false,
-    xcargs: xcargs
   )
 end
 

--- a/xcode/commonFastfile
+++ b/xcode/commonFastfile
@@ -148,7 +148,7 @@ private_lane :buildArchive do |options|
   lane_name = options[:lane_name]
   configuration = options[:configuration]
   xcodeproj_path = options[:xcodeproj_path]
-  xcargs = "FORCE_LINT=true" # To enable linting on project without CodeLint target
+  xcargs = "FORCE_LINT='true'" # To enable linting on project without CodeLint target
 
   if configuration != "AppStore" # AppStore uses xcconfig choosen in Xcode
     set_xcconfig_for_configuration_of_project(lane_name, configuration, xcodeproj_path)

--- a/xcode/commonFastfile
+++ b/xcode/commonFastfile
@@ -148,6 +148,7 @@ private_lane :buildArchive do |options|
   lane_name = options[:lane_name]
   configuration = options[:configuration]
   xcodeproj_path = options[:xcodeproj_path]
+  xcargs = "FORCE_LINT=true" # To enable linting on project without CodeLint target
 
   if configuration != "AppStore" # AppStore uses xcconfig choosen in Xcode
     set_xcconfig_for_configuration_of_project(lane_name, configuration, xcodeproj_path)
@@ -166,6 +167,7 @@ private_lane :buildArchive do |options|
     skip_package_ipa: options[:skip_package_ipa],
     include_symbols: options[:include_symbols] || false,
     include_bitcode: options[:compileBitcode] || false,
+    xcargs: xcargs
   )
 end
 


### PR DESCRIPTION
Правит issue: https://github.com/TouchInstinct/BuildScripts/issues/270:
- Новый скрипт позволяет линтовать только те файлы, что были изменены / добавлены в проект.    
- При этом поддерживается работа с `read_input_file_names.sh` и успешно работает excluded параметр в конфигурационном файле.
- Скрипт не умеет работать с untracked файлами и кажется, что и не должен
- В проектах необходимо добавит в .gitignore `swiftlint_files`
- Пропадает необходимость в данной реализации - https://github.com/TouchInstinct/BuildScripts/pull/213