### PR TITLE
feat: remove lazy_var

### DIFF
--- a/xcode/.swiftlint.yml
+++ b/xcode/.swiftlint.yml
@@ -266,12 +266,6 @@ custom_rules:
     regex: 'case[^\n\(]+\([^\)]*(let|var)\s'
     message: "Use a let|var keyword behind parentheses"
     severity: warning
-    
-  lazy_var:
-    name: "Lazy var access modifier"
-    regex: '(?<!private\(set\)\s)lazy\s+var'
-    message: "Lazy var can only be used with private(set) modifier."
-    severity: warning
 
   # Rx
 


### PR DESCRIPTION
Текущее правило некорректно обрабатывает private lazy var кейс - https://github.com/TouchInstinct/BuildScripts/issues/267