### PR TITLE
fix correct task search for android linter

### DIFF
--- a/gradle/plugins/src/main/java/static_analysis/linters/AndroidLinter.kt
+++ b/gradle/plugins/src/main/java/static_analysis/linters/AndroidLinter.kt
@@ -62,7 +62,11 @@ class AndroidLinter : Linter {
                 .mapNotNull { subproject: Project ->
                     subproject
                             .tasks
-                            .find { task -> task.name.contains(buildType, ignoreCase = true) && task.name.contains("lint") }
+                            .find { task ->
+                                task.name.contains(buildType, ignoreCase = true)
+                                        && task.name.contains("lint")
+                                        && !task.name.contains("lintVital")
+                            }
                             ?.path
                 }
     }


### PR DESCRIPTION
починил поиск задач для Андроид-линтера

на билдах есть две задачи: `lint` и `lintVital` (вторая, по всей видимости, является какой-то упрощенной версией)

если в списке задач `lintVital` идет первой, то `lint` не отрабатывает, и отчет `lint-report.xml` не генерируется

пример сборки: http://android.teamcity.ti/viewLog.html?tab=buildLog&logTab=tree&filter=debug&expand=all&buildId=43420&_focus=1375

![image](https://user-images.githubusercontent.com/1465932/139107223-e09bb36a-9851-47fb-be0c-ac6659a7d20d.png)
