### PR TITLE
Fix file paths when collect changes for linting

### DIFF
--- a/xcode/build_phases/swiftlint.sh
+++ b/xcode/build_phases/swiftlint.sh
@@ -67,7 +67,7 @@ else
         path_prefix="`git rev-parse --show-toplevel`/"
 
         # Отбираем файлы, которые были изменены или созданы
-        source_unstaged_files=$(git diff --diff-filter=d --name-only --line-prefix=${path_prefix} | grep "\.swift$")
+        source_unstaged_files=$(git diff --diff-filter=d --name-only --line-prefix=${path_prefix} ${SOURCE_DIR} | grep "\.swift$")
         source_staged_files=$(git diff --diff-filter=d --name-only --line-prefix=${path_prefix} --cached ${SOURCE_DIR} | grep "\.swift$")
 
         if [ ! -z "${source_unstaged_files}" ]; then

--- a/xcode/build_phases/swiftlint.sh
+++ b/xcode/build_phases/swiftlint.sh
@@ -63,10 +63,12 @@ else
 
     # Проходимся по папкам, которые требуют линтовки
     for SOURCE_DIR in ${SOURCES_DIRS}; do
+        # Путь к папке репозитория
+        path_prefix="`git rev-parse --show-toplevel`/"
 
         # Отбираем файлы, которые были изменены или созданы
-        source_unstaged_files=$(git diff --diff-filter=d --name-only ${SOURCE_DIR} | grep "\.swift$")
-        source_staged_files=$(git diff --diff-filter=d --name-only --cached ${SOURCE_DIR} | grep "\.swift$")
+        source_unstaged_files=$(git diff --diff-filter=d --name-only --line-prefix=${path_prefix} | grep "\.swift$")
+        source_staged_files=$(git diff --diff-filter=d --name-only --line-prefix=${path_prefix} --cached ${SOURCE_DIR} | grep "\.swift$")
 
         if [ ! -z "${source_unstaged_files}" ]; then
             echo "${source_unstaged_files}" >> ${lint_files_path}


### PR DESCRIPTION
`git diff --name-only` выдаёт относительные пути к файлам, линтер не может их найти и ничего не происходит:

![image](https://user-images.githubusercontent.com/19363752/140049639-0dafac4a-d09b-4b12-a153-4fda0700a4aa.png)

Если добавить к каждому файлу префикс в виде пути к папке репозитория, то список файлов генерируется нормально и линтинг срабатывает:

![image](https://user-images.githubusercontent.com/19363752/140049521-21fa19d1-a3a2-493d-a15f-fcdec8ca8cd3.png)