### PR TITLE
Deleted detekt.UseDataClass rule

### DIFF
--- a/static_analysis_configs/detekt-config.yml
+++ b/static_analysis_configs/detekt-config.yml
@@ -387,9 +387,6 @@ style:
   UnusedPrivateMember:
     active: true
     allowedNames: "(_|ignored|expected|serialVersionUID)"
-  UseDataClass:
-    active: true
-    excludeAnnotatedClasses: ""
   UtilityClassWithPublicConstructor:
     active: false
   VarCouldBeVal:


### PR DESCRIPTION
Удалено правило `detekt.UseDataClass`, ограничивающее создание классов без методов, так как не всегда нужны сгенерированные доп. методы `data`-класса