### PR TITLE
SwiftLint 0.45.1 adaptation

### DIFF
--- a/xcode/.swiftlint.yml
+++ b/xcode/.swiftlint.yml
@@ -107,11 +107,14 @@ enum_case_associated_values_count:
 identifier_name:
   excluded:
     - id
+    - to
     - ok
-    - URL
     - x
     - y
     - z
+
+opening_brace:
+  allow_multiline_func: true
 
 warning_threshold: 1
 

--- a/xcode/build_phases/swiftlint.sh
+++ b/xcode/build_phases/swiftlint.sh
@@ -61,11 +61,11 @@ else
     # Если файл существует, то просто его очистим, если нет - создадим
     > ${lint_files_path}
 
+    # Путь к папке репозитория
+    path_prefix="`git rev-parse --show-toplevel`/"
+
     # Проходимся по папкам, которые требуют линтовки
     for SOURCE_DIR in ${SOURCES_DIRS}; do
-        # Путь к папке репозитория
-        path_prefix="`git rev-parse --show-toplevel`/"
-
         # Отбираем файлы, которые были изменены или созданы
         source_unstaged_files=$(git diff --diff-filter=d --name-only --line-prefix=${path_prefix} ${SOURCE_DIR} | grep "\.swift$")
         source_staged_files=$(git diff --diff-filter=d --name-only --line-prefix=${path_prefix} --cached ${SOURCE_DIR} | grep "\.swift$")
@@ -81,6 +81,6 @@ else
 
     swiftlint_files_path="@${lint_files_path}"
 
-    ${SWIFTLINT_EXECUTABLE} autocorrect --path ${swiftlint_files_path} --config ${SWIFTLINT_CONFIG_PATH} --force-exclude --use-alternative-excluding
+    ${SWIFTLINT_EXECUTABLE} --fix --path ${swiftlint_files_path} --config ${SWIFTLINT_CONFIG_PATH} --force-exclude --use-alternative-excluding
     ${SWIFTLINT_EXECUTABLE} --path ${swiftlint_files_path} --config ${SWIFTLINT_CONFIG_PATH} --force-exclude --use-alternative-excluding
 fi


### PR DESCRIPTION
Прошёлся по релизам SwiftLint 0.39.1 - 0.45.1, новых полезных opt-in правил не заметил.

---

У `opening_brace` [появился](https://github.com/realm/SwiftLint/pull/3068) параметр `allow_multiline_func`, кажется нужным, разрешает перенести скобку на новую строку в функциях с многострочными параметрами:

```swift
// Выглядит более читаемо
func foo(bar: ParameterClosure<WibbleWobbleWubble>,
         baz: @escaping VoidClosure,
         qux: @escaping ParameterClosure<WibbleWobbleWubble>)
{
    // code
}

// Выглядит менее читаемо
func foo(bar: ParameterClosure<WibbleWobbleWubble>,
         baz: @escaping VoidClosure,
         qux: @escaping ParameterClosure<WibbleWobbleWubble>) {
    // code
}
```

---

В 0.43.0 заменили `swiftlint autocorrect` на `swiftlint --fix`.

---

Добавил название `to` в список исключений правила `identifier_name`, довольно распространённое название переменной, на мой взгляд:

```swift
func foo(from: Date, to: Date) {
    // code
}
```