### PR TITLE
Add .zprofile exporting

### DIFF
--- a/xcode/aux_scripts/install_env.sh
+++ b/xcode/aux_scripts/install_env.sh
@@ -33,7 +33,7 @@ function source_home_file {
 
 # Use specific exec due to Xcode has custom value of $PATH 
 if [ -z "$(which $1)" ]; then
-   source_home_file ".bash_profile" || source_home_file ".zshrc" || true
+   source_home_file ".bash_profile" || source_home_file ".zshrc" || source_home_file ".zprofile" || true
 
    echo "User defined enviroment has been set for ${1}"
 fi


### PR DESCRIPTION
# Проблема

![telegram-cloud-photo-size-2-5330363802761410507-y](https://user-images.githubusercontent.com/28960974/146683910-52fc729b-20c8-4226-b3ef-3ae428b261cb.jpg)

при запуске схемы CodeGen на чистой машине M1.

# Причина

homebrew после установки экспортирует path не в .zshrc, а в .zprofile:
<img width="465" alt="image" src="https://user-images.githubusercontent.com/28960974/146683973-f79b6d66-0e13-4739-9d16-c81706b8167a.png">

# Решение
Добавить экспорт .zprofile при экспорте пользовательского окружения