### PR TITLE
Configuration Type Prefix added

### DIFF
--- a/xcode/commonFastfile
+++ b/xcode/commonFastfile
@@ -407,7 +407,7 @@ def get_configuration_for_type(type)
 end
 
 def get_google_services_plist_path(app_target_folder_name, configuration_type)
-  File.expand_path "../#{app_target_folder_name}/Resources/GoogleService-Info.plist"
+  File.expand_path "../#{app_target_folder_name}/Resources/#{configuration_type.prefix}-GoogleService-Info.plist"
 end
 
 def generate_enabled_features_extension_if_needed(options)


### PR DESCRIPTION
Добавлен `configuration_type.prefix` для нахождения нужного файла `GoogleService-Info.plist` в проекте ВУЗ-банка. (Был ранее в commonFastfile, но был изменен при мердже мастера, сейчас вернул обратно)