### PR TITLE
VUZ | Increment build number in xcodeproj target added

### DIFF
--- a/xcode/commonFastfile
+++ b/xcode/commonFastfile
@@ -113,7 +113,8 @@ private_lane :buildConfiguration do |options|
   if is_ci
     increment_build_number_in_xcodeproj(
       build_number: options[:buildNumber],
-      xcodeproj: "./#{options[:appName]}.xcodeproj"
+      xcodeproj: "./#{options[:appName]}.xcodeproj",
+      target: options[:appName]
     )
   end
 


### PR DESCRIPTION
Без указания таргета ВУЗ-банк каждый раз обновлял в предыдущую сборку (без изменения номера), что, в какой-то момент, привело к проблемам корректной сборки проекта

---

- Добавил `target` при вызове `increment_build_number_in_xcodeproj`, благодаря чему стал корректно обновляться номер сборки
<p align="center">
<img src="https://user-images.githubusercontent.com/37587023/151028399-e01695cc-afa5-496f-bdf9-3170b2ad173c.jpg" width=40%/>
</p>