### PR TITLE
firebase_app_distribution groups file check added

### DIFF
--- a/xcode/commonFastfile
+++ b/xcode/commonFastfile
@@ -36,12 +36,24 @@ private_lane :uploadToFirebase do |options|
 
   google_app_id = get_info_plist_value(path: gsp_plist_path, key: "GOOGLE_APP_ID")
 
-  firebase_app_distribution(
+  firebase_app_distibution_groups_path = File.expand_path "../firebase_app_distribution_groups"
+
+  # Select groups_file or groups parameter depending on groups file existence
+  if File.exists? firebase_app_distibution_groups_path
+    firebase_app_distribution(
+      app: google_app_id,
+      ipa_path: options[:ipa_path],
+      groups_file: firebase_app_distibution_groups_path,
+      release_notes_file: releaseNotesFile
+    )
+  else
+    firebase_app_distribution(
       app: google_app_id,
       ipa_path: options[:ipa_path],
       groups: "touch-instinct",
       release_notes_file: releaseNotesFile
-  )
+    )
+  end
 
   upload_symbols_to_crashlytics(
     gsp_path: get_google_services_plist_path(app_target_folder_name, configuration_type)


### PR DESCRIPTION
### Добавлена возможность расширения групп тестирования для `firebase_app_distribution`

- Если в корневой папке проекта будет существовать файл `firebase_app_distribution_groups` с названиями групп тестирования, указаных **_через запятую_**, то при выполнении загрузки в `Firebase` в параметр `groups_file` будут браться все группы из этого файла;

- Если файл отсутствует, то используется параметр `groups` вместо `groups_file` и задаётся значение по умолчанию:  `touch-instinct`

---

Пример для проекта УБРиР:

- Выполнение скрипта **`при отсутствии файла`**

Сборка завершается успешно, доступ выдан только для группы `touch-instinct`

![Снимок экрана 2022-02-17 в 17 26 45](https://user-images.githubusercontent.com/37587023/154481618-cfb5a3e4-6000-4dfe-956e-9fdd5828ecfa.png)

![Снимок экрана 2022-02-17 в 16 48 52](https://user-images.githubusercontent.com/37587023/154481749-c20f319d-27c5-40f8-a31e-c9b482da5884.png)

- Выполнение скрипта **`при наличии файла`** с указанными группами `touch-instinct, ubrd-testing`

Сборка завершается успешно, доступ выдан для обеих групп тестирования

![Снимок экрана 2022-02-17 в 17 55 08](https://user-images.githubusercontent.com/37587023/154485984-d2524081-db9c-4f19-bf39-b701568a2c1f.png)

![Снимок экрана 2022-02-17 в 17 46 19](https://user-images.githubusercontent.com/37587023/154484689-8ea42e94-da3a-4321-a9e3-d6b83a2871b3.png)


 