### PR TITLE
add support for OpenAPI generation

### DIFF
--- a/xcode/aux_scripts/download_file.sh
+++ b/xcode/aux_scripts/download_file.sh
@@ -3,8 +3,8 @@ file_link=$2
 folder=$3
 flag_of_delete=$4
 
-readonly key_of_delete="--remove-cached"
-readonly default_folder="./Downloads"
+key_of_delete="--remove-cached"
+default_folder="./Downloads"
 
 if [[ ${folder} = ${key_of_delete} ]]; then
     folder="${default_folder}"

--- a/xcode/build_phases/api_generator.sh
+++ b/xcode/build_phases/api_generator.sh
@@ -5,9 +5,13 @@
 #
 # Parameters:
 #   $1 - api generator version.
+#   $2 - path to generated code directory
 #
 # Optional environment variables:
 #   OUTPUT_PATH - path to Generated folder.
+#   API_SPEC_DIR - path api specification folder
+#   VERBOSE - print debug messages
+#   API_NAME - project name that will be used by generator (example: OUTPUT_PATH/API_NAME/Classes )
 #
 # Examples of usage:
 #   . api_generator.sh 1.4.0-beta1
@@ -19,6 +23,20 @@ readonly EXIT_FAILURE=1
 
 readonly TRUE=0
 readonly FALSE=1
+
+readonly LOG_TAG="API-GENERATOR"
+
+notice()
+{
+    echo "${LOG_TAG}:NOTICE: ${1}"
+}
+
+debug()
+{
+    if [ ! -z "${VERBOSE}" ]; then
+        echo "${LOG_TAG}:DEBUG: ${1}"
+    fi
+}
 
 is_force_run()
 {
@@ -37,25 +55,21 @@ is_force_run()
 
 get_current_commit()
 {
-    if [ -z "${CURRENT_COMMIT}" ]; then
-        if [ -z "${REPO_PATH}" ]; then
-            if [ ! -z "${1}" ]; then
-                echo `git -C ${1} rev-parse --verify HEAD`
-            else
-                echo `git rev-parse --verify HEAD`
-            fi
+    if [ -z "${API_SPEC_DIR}" ]; then
+        if [ ! -z "${1}" ]; then
+            echo `git -C ${1} rev-parse --verify HEAD`
         else
-            echo `git -C ${REPO_PATH} rev-parse --verify HEAD`
+            echo `git rev-parse --verify HEAD`
         fi
     else
-        echo ${CURRENT_COMMIT}
+        echo `git -C ${API_SPEC_DIR} rev-parse --verify HEAD`
     fi
 }
 
 is_nothing_changed_since_last_check()
 {
     if is_force_run; then
-        echo "Force run detected. Skipping commits comparison."
+        notice "Force run detected. Skipping commits comparison."
         return ${EXIT_FAILURE}
     fi
 
@@ -63,18 +77,14 @@ is_nothing_changed_since_last_check()
         if [ ! -z "${1}" ]; then
             local -r COMMIT_FILE_PATH=${1}
         else
-            echo "COMMIT_FILE_PATH should be defined or passed as first argument!"
+            debug "COMMIT_FILE_PATH should be defined or passed as first argument!"
             return ${EXIT_FAILURE}
         fi
     fi
 
-    if [ -z "${2}" ]; then
-        local -r CURRENT_COMMIT=`get_current_commit`
-    else
-        local -r CURRENT_COMMIT=${2}
-    fi
+    local -r CURRENT_COMMIT=`get_current_commit`
 
-    local -r LAST_CHECKED_COMMIT=`cat ${COMMIT_FILE_PATH}` || ""
+    local -r LAST_CHECKED_COMMIT=`cat ${COMMIT_FILE_PATH} 2> /dev/null || echo ""`
 
     if [ ${CURRENT_COMMIT} = "${LAST_CHECKED_COMMIT}" ]; then
         return ${EXIT_SUCCESS}
@@ -86,26 +96,112 @@ is_nothing_changed_since_last_check()
 record_current_commit()
 {
     if is_force_run; then
-        echo "Force run detected. Commit won't be recorder."
+        notice "Force run detected. Commit won't be recorder."
         exit ${EXIT_SUCCESS}
     fi
 
-    if [ -z "${1}" ]; then
-        local -r CURRENT_COMMIT=`get_current_commit`
-    else
-        local -r CURRENT_COMMIT=${1}
-    fi
-
     if [ -z "${COMMIT_FILE_PATH}" ]; then
-        if [ ! -v "${2}" ]; then
-            local -r COMMIT_FILE_PATH=${2}
+        if [ ! -v "${1}" ]; then
+            local -r COMMIT_FILE_PATH=${1}
         else
-            echo "COMMIT_FILE_PATH should be defined or passed as second argument!"
+            debug "COMMIT_FILE_PATH should be defined or passed as second argument!"
             return ${EXIT_FAILURE}
         fi
     fi
 
+    local -r CURRENT_COMMIT=`get_current_commit`
+
     echo ${CURRENT_COMMIT} > ${COMMIT_FILE_PATH}
+}
+
+openapi_codegen()
+{
+    if [ -z "${YAML_FILE}" ]; then
+        if [ ! -v "${1}" ]; then
+            local -r YAML_FILE=${1}
+        else
+            debug "YAML_FILE should be defined or passed as first argument!"
+            return ${EXIT_FAILURE}
+        fi
+    fi
+
+    if [ -z "${OUTPUT_PATH}" ]; then
+        if [ ! -v "${2}" ]; then
+            local -r OUTPUT_PATH=${2}
+        else
+            debug "OUTPUT_PATH should be defined or passed as second argument!"
+            return ${EXIT_FAILURE}
+        fi
+    fi
+
+    if [ -z "${VERSION}" ]; then
+        if [ ! -v "${3}" ]; then
+            local -r VERSION=${3}
+        else
+            debug "VERSION should be defined or passed as third argument!"
+            return ${EXIT_FAILURE}
+        fi
+    fi
+
+    if [ -z "${API_NAME}" ]; then
+        local -r API_NAME="${PROJECT_NAME}API"
+    fi
+
+    notice "OpenAPI spec generation for ${YAML_FILE}"
+
+    local -r CODEGEN_VERSION="3.0.33"
+
+    local -r CODEGEN_FILE_NAME="swagger-codegen-cli-${CODEGEN_VERSION}.jar"
+    local -r CODEGEN_DOWNLOAD_URL="https://repo1.maven.org/maven2/io/swagger/codegen/v3/swagger-codegen-cli/${CODEGEN_VERSION}/${CODEGEN_FILE_NAME}"
+
+    . build-scripts/xcode/aux_scripts/download_file.sh ${CODEGEN_FILE_NAME} ${CODEGEN_DOWNLOAD_URL}
+
+    local -r TINETWORKING_CODEGEN_FILE_NAME="codegen-${VERSION}.jar"
+
+    local -r DOWNLOAD_URL="https://maven.dev.touchin.ru/ru/touchin/codegen/${VERSION}/${TINETWORKING_CODEGEN_FILE_NAME}"
+
+    . build-scripts/xcode/aux_scripts/download_file.sh ${TINETWORKING_CODEGEN_FILE_NAME} ${DOWNLOAD_URL}
+
+    java -cp "Downloads/${CODEGEN_FILE_NAME}:Downloads/${TINETWORKING_CODEGEN_FILE_NAME}" io.swagger.codegen.v3.cli.SwaggerCodegen generate -l TINetworking -i ${YAML_FILE} -o ${OUTPUT_PATH} --additional-properties projectName:PetshopAPI
+}
+
+api_generator_codegen()
+{
+    if [ -z "${API_SPEC_DIR}" ]; then
+        if [ ! -v "${1}" ]; then
+            local -r API_SPEC_DIR=${1}
+        else
+            debug "API_SPEC_DIR should be defined or passed as first argument!"
+            return ${EXIT_FAILURE}
+        fi
+    fi
+
+    if [ -z "${OUTPUT_PATH}" ]; then
+        if [ ! -v "${2}" ]; then
+            local -r OUTPUT_PATH=${2}
+        else
+            debug "OUTPUT_PATH should be defined or passed as second argument!"
+            return ${EXIT_FAILURE}
+        fi
+    fi
+
+    if [ -z "${VERSION}" ]; then
+        if [ ! -v "${3}" ]; then
+            local -r VERSION=${3}
+        else
+            debug "VERSION should be defined or passed as third argument!"
+            return ${EXIT_FAILURE}
+        fi
+    fi
+
+    notice "api-generator spec generation for ${API_SPEC_DIR}/main.json"
+
+    local -r FILE_NAME="api-generator-${VERSION}.jar"
+    local -r DOWNLOAD_URL="https://maven.dev.touchin.ru/ru/touchin/api-generator/${VERSION}/${FILE_NAME}"
+
+    . build-scripts/xcode/aux_scripts/download_file.sh ${FILE_NAME} ${DOWNLOAD_URL}
+
+    java -Xmx6g -jar "Downloads/${FILE_NAME}" generate-client-code --output-language SWIFT --specification-path ${API_SPEC_DIR} --output-path ${OUTPUT_PATH} --single-file true
 }
 
 readonly BUILD_PHASES_DIR=${SRCROOT}/build_phases
@@ -114,15 +210,12 @@ mkdir -p ${BUILD_PHASES_DIR}
 
 readonly COMMIT_FILE_PATH=${BUILD_PHASES_DIR}/api-generator-commit
 
-readonly REPO_PATH="common"
-
 if is_nothing_changed_since_last_check; then
-    echo "Nothing was changed models generation skipped."
+    notice "Nothing was changed api generation skipped."
     exit ${EXIT_SUCCESS}
 fi
 
-VERSION=$1
-FILE_NAME="api-generator-${VERSION}.jar"
+readonly VERSION=$1
 
 if [ -z "${OUTPUT_PATH}" ]; then
     if [ ! -z "${2}" ]; then
@@ -132,13 +225,22 @@ if [ -z "${OUTPUT_PATH}" ]; then
     fi
 fi
 
+if [ -z "${API_SPEC_DIR}" ]; then
+    readonly API_SPEC_DIR="common"
+fi
+
 mkdir -p ${OUTPUT_PATH}
 
-# download api generator
-readonly DOWNLOAD_URL="https://maven.dev.touchin.ru/ru/touchin/api-generator/${VERSION}/${FILE_NAME}"
-. build-scripts/xcode/aux_scripts/download_file.sh ${FILE_NAME} ${DOWNLOAD_URL}
+readonly YAML_FILE=`find ${API_SPEC_DIR} -maxdepth 1 -name '*.yaml' -o -name '*.yml' | head -n 1`
 
-# execute api generator
-java -Xmx6g -jar "Downloads/${FILE_NAME}" generate-client-code --output-language SWIFT --specification-path common/api --output-path ${OUTPUT_PATH} --single-file true
+if [ -f "${YAML_FILE}" ]; then
+    openapi_codegen
+elif [ -f "${API_SPEC_DIR}/main.json" ]; then
+    api_generator_codegen
+else
+    exit ${EXIT_FAILURE}
+fi
 
-record_current_commit
+if [ $? -ne ${EXIT_FAILURE} ]; then
+    record_current_commit 
+fi

--- a/xcode/build_phases/api_generator.sh
+++ b/xcode/build_phases/api_generator.sh
@@ -9,7 +9,7 @@
 #
 # Optional environment variables:
 #   OUTPUT_PATH - path to Generated folder.
-#   API_SPEC_DIR - path api specification folder
+#   API_SPEC_DIR - path to api specification folder
 #   VERBOSE - print debug messages
 #   API_NAME - project name that will be used by generator (example: OUTPUT_PATH/API_NAME/Classes )
 #
@@ -162,7 +162,7 @@ openapi_codegen()
 
     . build-scripts/xcode/aux_scripts/download_file.sh ${TINETWORKING_CODEGEN_FILE_NAME} ${DOWNLOAD_URL}
 
-    java -cp "Downloads/${CODEGEN_FILE_NAME}:Downloads/${TINETWORKING_CODEGEN_FILE_NAME}" io.swagger.codegen.v3.cli.SwaggerCodegen generate -l TINetworking -i ${YAML_FILE} -o ${OUTPUT_PATH} --additional-properties projectName:PetshopAPI
+    java -cp "Downloads/${CODEGEN_FILE_NAME}:Downloads/${TINETWORKING_CODEGEN_FILE_NAME}" io.swagger.codegen.v3.cli.SwaggerCodegen generate -l TINetworking -i ${YAML_FILE} -o ${OUTPUT_PATH} --additional-properties projectName:${API_NAME}
 }
 
 api_generator_codegen()


### PR DESCRIPTION
Теперь поддерживается генерация моделей и методов OpenAPI.

Команда не поменялась. Что генерить определяется исходя из наличия yaml или json файлов

```sh
. build-scripts/xcode/build_phases/api_generator.sh 1.0.0 ${TARGET_NAME}/Generated
```

или

```sh
API_SPEC_DIR=SwaggerApiSpec
API_NAME=ProjectNameAPI

. build-scripts/xcode/build_phases/api_generator.sh 1.0.0 ${TARGET_NAME}/Generated
```