### PR TITLE
add support for custom abstract targets in path to cocoapods xcconfigfiles. 

### DIFF
--- a/xcode/config_generator/example_settings.yaml
+++ b/xcode/config_generator/example_settings.yaml
@@ -1,5 +1,6 @@
 targets:
   TestProject:
+    abstract_targets_prefix: "-TestProjectKit"
     development:
       PRODUCT_BUNDLE_IDENTIFIER: "ru.touchin.testproject"
       PROVISIONING_PROFILE_SPECIFIER: "TestProjectDev"

--- a/xcode/config_generator/render_xcconfigs.rb
+++ b/xcode/config_generator/render_xcconfigs.rb
@@ -115,6 +115,7 @@ targets.each do |target_name, target|
         # Create settings pack
         config_data = {
             "target_name": target_name,
+            "abstract_targets_prefix": target["abstract_targets_prefix"],
             "configuration": config
         }
 

--- a/xcode/config_generator/target_xcconfig.mustache
+++ b/xcode/config_generator/target_xcconfig.mustache
@@ -1,4 +1,4 @@
-#include "Pods/Target Support Files/Pods-{{target_name}}/Pods-{{target_name}}.{{configuration.build_type}}.xcconfig"
+#include "Pods/Target Support Files/Pods{{abstract_targets_prefix}}-{{target_name}}/Pods{{abstract_targets_prefix}}-{{target_name}}.{{configuration.build_type}}.xcconfig"
 
 {{#configuration.xcconfig_options}}
 {{key}} = {{value}}


### PR DESCRIPTION
closes #236