### PR TITLE
Setup lint before evaluate

### DIFF
--- a/gradle/plugins/src/main/java/static_analysis/linters/AndroidLinter.kt
+++ b/gradle/plugins/src/main/java/static_analysis/linters/AndroidLinter.kt
@@ -33,8 +33,8 @@ class AndroidLinter : Linter {
             .flatten()
 
     override fun setupForProject(project: Project, extension: StaticAnalysisExtension) {
-        project.gradle.projectsEvaluated {
-            project.subprojects
+        project.beforeEvaluate {
+            subprojects
                     .mapNotNull { it.extensions.findByType<AppExtension>() }
                     .first()
                     .lintOptions.apply {
@@ -45,8 +45,8 @@ class AndroidLinter : Linter {
                         htmlReport = false
                         isCheckDependencies = true
                         disable("MissingConstraints", "VectorRaster")
-                        xmlOutput = project.getLintReportFile()
-                        lintConfig = project.file("${extension.buildScriptDir}/static_analysis_configs/lint.xml")
+                        xmlOutput = getLintReportFile()
+                        lintConfig = file("${extension.buildScriptDir}/static_analysis_configs/lint.xml")
                     }
         }
     }

--- a/gradle/plugins/src/main/java/static_analysis/linters/CpdLinter.kt
+++ b/gradle/plugins/src/main/java/static_analysis/linters/CpdLinter.kt
@@ -34,15 +34,18 @@ class CpdLinter : Linter {
             }
 
     override fun setupForProject(project: Project, extension: StaticAnalysisExtension) {
-        project.extensions.findByType<CpdExtension>()!!.apply {
-            isSkipLexicalErrors = true
-            language = "kotlin"
-            minimumTokenCount = 60
-        }
-        project.tasks.withType<Cpd> {
-            reports.xml.destination = project.getCpdReportFile()
-            ignoreFailures = true
-            source = project.getSources(extension.excludes)
+        project.afterEvaluate {
+            extensions.findByType<CpdExtension>()!!.apply {
+                isSkipLexicalErrors = true
+                language = "kotlin"
+                minimumTokenCount = 60
+            }
+            tasks.withType<Cpd> {
+                reports.xml.required.set(true)
+                reports.xml.destination = getCpdReportFile()
+                ignoreFailures = true
+                source = getSources(extension.excludes)
+            }
         }
     }
 

--- a/gradle/plugins/src/main/java/static_analysis/linters/DetektLinter.kt
+++ b/gradle/plugins/src/main/java/static_analysis/linters/DetektLinter.kt
@@ -32,27 +32,27 @@ class DetektLinter : Linter {
             .flatten()
 
     override fun setupForProject(project: Project, extension: StaticAnalysisExtension) {
-        project
-                .tasks
-                .withType(Detekt::class.java) {
-                    exclude("**/test/**")
-                    exclude("resources/")
-                    exclude("build/")
-                    exclude("tmp/")
-                    jvmTarget = "1.8"
+        project.afterEvaluate {
+            tasks.withType(Detekt::class.java) {
+                exclude("**/test/**")
+                exclude("resources/")
+                exclude("build/")
+                exclude("tmp/")
+                jvmTarget = "1.8"
 
-                    config.setFrom(project.files("${extension.buildScriptDir!!}/static_analysis_configs/detekt-config.yml"))
-                    reports {
-                        txt.enabled = false
-                        html.enabled = false
-                        xml {
-                            enabled = true
-                            destination = project.getDetektReportFile()
-                        }
+                config.setFrom(files("${extension.buildScriptDir!!}/static_analysis_configs/detekt-config.yml"))
+                reports {
+                    txt.enabled = false
+                    html.enabled = false
+                    xml {
+                        enabled = true
+                        destination = getDetektReportFile()
                     }
-
-                    source = project.getSources(extension.excludes)
                 }
+
+                source = getSources(extension.excludes)
+            }
+        }
     }
 
     override fun getTaskNames(project: Project, buildType: String?): List<String> = listOf(":detekt")

--- a/gradle/plugins/src/main/java/static_analysis/plugins/StaticAnalysisAndroidPlugin.kt
+++ b/gradle/plugins/src/main/java/static_analysis/plugins/StaticAnalysisAndroidPlugin.kt
@@ -28,8 +28,6 @@ class StaticAnalysisAndroidPlugin : StaticAnalysisPlugin() {
                         )
                     }
                 }
-
-
             }
         }
     }

--- a/gradle/plugins/src/main/java/static_analysis/plugins/StaticAnalysisPlugin.kt
+++ b/gradle/plugins/src/main/java/static_analysis/plugins/StaticAnalysisPlugin.kt
@@ -26,9 +26,7 @@ abstract class StaticAnalysisPlugin : Plugin<Project> {
 
             val linters = createLinters()
 
-            beforeEvaluate {
-                linters.forEach { it.setupForProject(target, extensions.getByType()) }
-            }
+            linters.forEach { it.setupForProject(target, extensions.getByType()) }
 
             gradle.projectsEvaluated {
                 createStaticAnalysisTasks(target, linters)

--- a/gradle/plugins/src/main/java/static_analysis/plugins/StaticAnalysisPlugin.kt
+++ b/gradle/plugins/src/main/java/static_analysis/plugins/StaticAnalysisPlugin.kt
@@ -26,7 +26,7 @@ abstract class StaticAnalysisPlugin : Plugin<Project> {
 
             val linters = createLinters()
 
-            afterEvaluate {
+            beforeEvaluate {
                 linters.forEach { it.setupForProject(target, extensions.getByType()) }
             }
 


### PR DESCRIPTION
После обновления `AGP` появилась ошибка в конфигурации `AndroidLinter`, т.к. она выполняется после оценки всего проекта
Перенес выбор времени настройки линтера в `setupProject`