### PR TITLE
Add multiple files generation optional flag

### DIFF
--- a/xcode/build_phases/api_generator.sh
+++ b/xcode/build_phases/api_generator.sh
@@ -227,7 +227,6 @@ api_generator_codegen()
     local -r DOWNLOAD_URL="https://maven.dev.touchin.ru/ru/touchin/api-generator/${VERSION}/${FILE_NAME}"
 
     . build-scripts/xcode/aux_scripts/download_file.sh ${FILE_NAME} ${DOWNLOAD_URL}
-    notice $(is_single_file)
     java -Xmx6g -jar "Downloads/${FILE_NAME}" generate-client-code --output-language SWIFT --specification-path ${API_SPEC_DIR} --output-path ${OUTPUT_PATH} --single-file $(is_single_file)
 }
 

--- a/xcode/build_phases/api_generator.sh
+++ b/xcode/build_phases/api_generator.sh
@@ -3,9 +3,6 @@
 # Description:
 #   Generates API models & methods.
 #
-# Optional flags:
-#   -m - generate api in multiple files
-#
 # Parameters:
 #   $1 - api generator version.
 #   $2 - path to generated code directory
@@ -32,14 +29,6 @@ readonly FALSE=1
 
 readonly LOG_TAG="API-GENERATOR"
 
-help()
-{
-    local HELP_MESSAGE="Flags:
-    -m - Generate multiple files api"
-
-    echo "${HELP_MESSAGE}"
-}
-
 notice()
 {
     echo "${LOG_TAG}:NOTICE: ${1}"
@@ -65,6 +54,22 @@ is_force_run()
     fi
 
     return ${FALSE}
+}
+
+is_single_file()
+{
+    if [ -z "${SINGLE_FILE}" ]; then
+        echo "true"
+        return
+    fi
+
+    local -r STR_MODE=`tr "[:upper:]" "[:lower:]" <<< ${SINGLE_FILE}`
+
+    if [ ${STR_MODE} == "no" ] || [ ${STR_MODE} == "false" ] || [ ${STR_MODE} == "0" ]; then
+        echo "false"
+    else 
+        echo "true"
+    fi
 }
 
 get_current_commit()
@@ -189,8 +194,6 @@ openapi_codegen()
 
 api_generator_codegen()
 {
-    local SINGLE_FILE="$1"
-
     if [ -z "${API_SPEC_DIR}" ]; then
         if [ ! -v "${1}" ]; then
             local -r API_SPEC_DIR=${1}
@@ -224,29 +227,9 @@ api_generator_codegen()
     local -r DOWNLOAD_URL="https://maven.dev.touchin.ru/ru/touchin/api-generator/${VERSION}/${FILE_NAME}"
 
     . build-scripts/xcode/aux_scripts/download_file.sh ${FILE_NAME} ${DOWNLOAD_URL}
-
-    java -Xmx6g -jar "Downloads/${FILE_NAME}" generate-client-code --output-language SWIFT --specification-path ${API_SPEC_DIR} --output-path ${OUTPUT_PATH} --single-file ${SINGLE_FILE}
+    notice $(is_single_file)
+    java -Xmx6g -jar "Downloads/${FILE_NAME}" generate-client-code --output-language SWIFT --specification-path ${API_SPEC_DIR} --output-path ${OUTPUT_PATH} --single-file $(is_single_file)
 }
-
-SINGLE_FILE=true
-
-while getopts "hm" OPTION; do
-  case "${OPTION}" in
-    h)
-      help
-      ;;
-    m)
-      notice "Multiple files option detected"
-      SINGLE_FILE=false  # Defines -m flag to generate api with multiple files
-      ;;
-    ?)
-      notice "Unknown option -$OPTARG"
-      exit ${EXIT_FAILURE} 
-      ;;
-  esac
-done
-
-shift "$(($OPTIND -1))" # Remove the parsed options from positional params
 
 readonly BUILD_PHASES_DIR=${SRCROOT}/build_phases
 
@@ -280,7 +263,7 @@ readonly OPEN_API_SPEC_PATH=`find ${API_SPEC_DIR} -maxdepth 1 -name '*.yaml' -o 
 if [ -f "${OPEN_API_SPEC_PATH}" ]; then
     openapi_codegen
 elif [ -f "${API_SPEC_DIR}/main.json" ]; then
-    api_generator_codegen ${SINGLE_FILE}
+    api_generator_codegen
 else
     notice "No api spec found!"
     exit ${EXIT_FAILURE}

--- a/xcode/build_phases/api_generator.sh
+++ b/xcode/build_phases/api_generator.sh
@@ -227,6 +227,7 @@ api_generator_codegen()
     local -r DOWNLOAD_URL="https://maven.dev.touchin.ru/ru/touchin/api-generator/${VERSION}/${FILE_NAME}"
 
     . build-scripts/xcode/aux_scripts/download_file.sh ${FILE_NAME} ${DOWNLOAD_URL}
+
     java -Xmx6g -jar "Downloads/${FILE_NAME}" generate-client-code --output-language SWIFT --specification-path ${API_SPEC_DIR} --output-path ${OUTPUT_PATH} --single-file $(is_single_file)
 }
 


### PR DESCRIPTION
Опциональный флаг генерации апи в нескольких файлах
---

- Добавил опциональный флаг для генерации апи в нескольких файлах

пример вызова: 
```bash
readonly SINGLE_FILE=false
. build-scripts/xcode/build_phases/api_generator.sh 1.4.0-alpha3 Resources/Generated
```