### PR TITLE
API Generator `-Xmx` parameter updated to 12Gb

### DIFF
--- a/xcode/build_phases/api_generator.sh
+++ b/xcode/build_phases/api_generator.sh
@@ -228,7 +228,7 @@ api_generator_codegen()
 
     . build-scripts/xcode/aux_scripts/download_file.sh ${FILE_NAME} ${DOWNLOAD_URL}
 
-    java -Xmx6g -jar "Downloads/${FILE_NAME}" generate-client-code --output-language SWIFT --specification-path ${API_SPEC_DIR} --output-path ${OUTPUT_PATH} --single-file $(is_single_file)
+    java -Xmx12g -jar "Downloads/${FILE_NAME}" generate-client-code --output-language SWIFT --specification-path ${API_SPEC_DIR} --output-path ${OUTPUT_PATH} --single-file $(is_single_file)
 }
 
 readonly BUILD_PHASES_DIR=${SRCROOT}/build_phases


### PR DESCRIPTION
## Обновление значения `-Xmx` параметра

- После добавления возможности разделения моделей на отдельные файлы, появилась проблема, при которой API-генератор падает с ошибкой `OutOfMemoryError` (пример сборки - [#14675](http://ios.teamcity.ti/viewLog.html?buildId=51167&buildTypeId=Ubrd_BuildIOS&tab=buildLog&_focus=1427) для проекта УБРиР). Значение максимально допустимой используемой памяти увеличено до `12 Гб`