### PR TITLE
API Generator codegen fixed

### DIFF
--- a/xcode/build_phases/api_generator.sh
+++ b/xcode/build_phases/api_generator.sh
@@ -87,15 +87,19 @@ get_api_spec_current_commit()
 
 is_api_spec_under_source_control()
 {
+    local IS_UNDER_SOURCE_CONTROL_CHECK
+    
     if [ -z "${API_SPEC_DIR}" ]; then
         if [ ! -z "${1}" ]; then
-            echo `git -C ${1} rev-parse --is-inside-work-tree 2>/dev/null`
+            IS_UNDER_SOURCE_CONTROL_CHECK=`git -C ${1} rev-parse --is-inside-work-tree 2>/dev/null`
         else
-            echo `git rev-parse --is-inside-work-tree 2>/dev/null`
+            IS_UNDER_SOURCE_CONTROL_CHECK=`git rev-parse --is-inside-work-tree 2>/dev/null`
         fi
     else
-        echo `git -C ${API_SPEC_DIR} rev-parse --is-inside-work-tree 2>/dev/null`
+        IS_UNDER_SOURCE_CONTROL_CHECK=`git -C ${API_SPEC_DIR} rev-parse --is-inside-work-tree 2>/dev/null`
     fi
+    
+    [ ${IS_UNDER_SOURCE_CONTROL_CHECK} = "true" ]
 }
 
 is_nothing_changed_since_last_check()
@@ -114,7 +118,7 @@ is_nothing_changed_since_last_check()
         fi
     fi
 
-    if [ `is_api_spec_under_source_control` == "true" ]; then
+    if is_api_spec_under_source_control; then
         local -r CURRENT_COMMIT=`get_api_spec_current_commit`
 
         local -r LAST_CHECKED_COMMIT=`cat ${COMMIT_FILE_PATH} 2> /dev/null || echo ""`

--- a/xcode/build_phases/api_generator.sh
+++ b/xcode/build_phases/api_generator.sh
@@ -76,12 +76,12 @@ get_api_spec_current_commit()
 {
     if [ -z "${API_SPEC_DIR}" ]; then
         if [ ! -z "${1}" ]; then
-            echo `git rev-parse HEAD:${1}`
+            echo `git -C ${1} rev-parse --verify HEAD`
         else
-            echo `git rev-parse HEAD`
+            echo `git rev-parse --verify HEAD`
         fi
     else
-        echo `git rev-parse HEAD:${API_SPEC_DIR}`
+        echo `git -C ${API_SPEC_DIR} rev-parse --verify HEAD`
     fi
 }
 
@@ -114,7 +114,7 @@ is_nothing_changed_since_last_check()
         fi
     fi
 
-    if [ is_api_spec_under_source_control == "true" ]; then
+    if [ `is_api_spec_under_source_control` == "true" ]; then
         local -r CURRENT_COMMIT=`get_api_spec_current_commit`
 
         local -r LAST_CHECKED_COMMIT=`cat ${COMMIT_FILE_PATH} 2> /dev/null || echo ""`


### PR DESCRIPTION
## Исправление проверки последних изменений по API-спецификации

- Вернул предыдущую логику получения текущего хэша коммита API-спецификации. Существующая брала некорректный хэш - текущий локальный вместо выбранного;
- Метод `is_api_spec_under_source_control` теперь возвращает напрямую значение типа `Bool` для меньшей путаницы при работе со скриптом

### Результат - корректное обновление как строк, так и `моделей` проекта

<img width="1406" alt="Снимок экрана 2022-09-05 в 23 36 19" src="https://user-images.githubusercontent.com/37587023/188501063-43b8f2c9-e4f7-4359-a42d-0ad3d895a0b1.png">
