### PR TITLE
API key configuration with environment variable added

### DIFF
--- a/xcode/commonFastfile
+++ b/xcode/commonFastfile
@@ -374,11 +374,8 @@ end
 def fill_up_options_using_configuration_type(options, configuration_type)
   configuration = get_configuration_for_type(configuration_type.type)
 
-  api_key_json_path = File.expand_path "../fastlane/#{configuration_type.prefix}_api_key.json"
-  is_api_key_file_exists = File.exists?(api_key_json_path)
-
-  api_key_path = nil
-  api_key = nil
+  api_key_path = File.expand_path "../fastlane/#{configuration_type.prefix}_api_key.json"
+  is_api_key_file_exists = File.exists?(api_key_path)
 
   # Check whether configuration type is required to configure one of api key parameters or not
 
@@ -389,38 +386,36 @@ def fill_up_options_using_configuration_type(options, configuration_type)
     if is_api_key_file_exists
 
       # If exists then fill in all required information through api_key_path parameter
+      # and set a value to an options` parameter respectively 
 
-      api_key_path = "fastlane/#{configuration_type.prefix}_api_key.json"
+      default_options = {:api_key_path => api_key_path}
     else
 
-      require 'json'
-
       # If doesn't exist then build api_key parameter through app_store_connect_api_key action
+      # and set a value to an options` parameter respectively also
 
-      api_key_parameters = JSON.parse(ENV['API_KEY_JSON'])
-
-      api_key = app_store_connect_api_key(
-        key_id: api_key_parameters['key_id'],
-        issuer_id: api_key_parameters['issuer_id'],
-        key_content: api_key_parameters['key'],
-        duration: api_key_parameters['duration'],
-        in_house: api_key_parameters['in_house']
-      )
+      default_options = {:api_key => get_app_store_connect_api_key()}
     end
-  end
-
-  # Setting required parameter depending on API key JSON file existence
-
-  if is_api_key_file_exists
-    default_options = {:api_key_path => api_key_path}
-  else
-    default_options = {:api_key => api_key}
   end
 
   default_options
     .merge(configuration.to_options)
     .merge(get_keychain_options(options))
     .merge(options)
+end
+
+def get_app_store_connect_api_key()
+  require 'json'
+
+  api_key_parameters = JSON.parse(ENV['API_KEY_JSON'])
+
+  return app_store_connect_api_key(
+    key_id: api_key_parameters['key_id'],
+    issuer_id: api_key_parameters['issuer_id'],
+    key_content: api_key_parameters['key'],
+    duration: api_key_parameters['duration'],
+    in_house: api_key_parameters['in_house']
+  )
 end
 
 def get_keychain_options(options)

--- a/xcode/commonFastfile
+++ b/xcode/commonFastfile
@@ -64,6 +64,7 @@ def upload_to_app_store_using_options(options)
   upload_to_app_store(
     username: options[:username] || options[:apple_id],
     api_key_path: options[:api_key_path],
+    api_key: options[:api_key],
     ipa: options[:ipa_path],
     force: true, # skip metainfo prompt
     skip_metadata: true,
@@ -348,6 +349,7 @@ def sync_code_signing_using_options(options)
     app_identifier: options[:app_identifier],
     username: options[:username] || options[:apple_id],
     api_key_path: options[:api_key_path],
+    api_key: options[:api_key],
     team_id: options[:team_id],
     type: options[:type],
     readonly: options[:readonly].nil? ? true : options[:readonly],
@@ -372,13 +374,48 @@ end
 def fill_up_options_using_configuration_type(options, configuration_type)
   configuration = get_configuration_for_type(configuration_type.type)
 
+  api_key_json_path = File.expand_path "../fastlane/#{configuration_type.prefix}_api_key.json"
+  is_api_key_file_exists = File.exists?(api_key_json_path)
+
+  api_key_path = nil
+  api_key = nil
+
+  # Check whether configuration type is required to configure one of api key parameters or not
+
   if configuration_type.is_app_store || configuration_type.is_development
-    api_key_path = "fastlane/#{configuration_type.prefix}_api_key.json"
-  else
-    api_key_path = nil
+
+    # Check whether API key JSON file exists or not
+
+    if is_api_key_file_exists
+
+      # If exists then fill in all required information through api_key_path parameter
+
+      api_key_path = "fastlane/#{configuration_type.prefix}_api_key.json"
+    else
+
+      require 'json'
+
+      # If doesn't exist then build api_key parameter through app_store_connect_api_key action
+
+      api_key_parameters = JSON.parse(ENV['API_KEY_JSON'])
+
+      api_key = app_store_connect_api_key(
+        key_id: api_key_parameters['key_id'],
+        issuer_id: api_key_parameters['issuer_id'],
+        key_content: api_key_parameters['key'],
+        duration: api_key_parameters['duration'],
+        in_house: api_key_parameters['in_house']
+      )
+    end
   end
 
-  default_options = {:api_key_path => api_key_path}
+  # Setting required parameter depending on API key JSON file existence
+
+  if is_api_key_file_exists
+    default_options = {:api_key_path => api_key_path}
+  else
+    default_options = {:api_key => api_key}
+  end
 
   default_options
     .merge(configuration.to_options)


### PR DESCRIPTION
## Добавление считывания данных API Key при отсутствии соответствующих файлов в проекте

- Добавил проверку на наличие файла в соответствующей папке, при наличии - используем его, как и ранее, а при отсутствии - используем переменную окружения, которая содержит в себе все необходимые данные - считываем JSON в словарь и получаем ключ с помощью действия `app_store_connect_api_key`. В итоге задаем тот параметр, который в итоге необходим в зависимости от наличия или отсутствия файла `api_key.json`

> P.S. Задача выполняется в рамках багов ИБ для проекте "Привет, Мир!" - [MIR-3547](https://jira.touchin.ru/browse/MIR-3547)

### Результат

### > Успешная [сборка](http://ios.teamcity.ti/viewLog.html?buildId=52777&buildTypeId=Mir_BuildIOS&tab=buildResultsDiv) проекта с наличием файла `api_key.json`

Для действия `match` и дальнейшей работы заполняется параметр `api_key_path` - [доказательство](http://ios.teamcity.ti/viewLog.html?buildId=52777&buildTypeId=Mir_BuildIOS&tab=buildLog&_focus=557#_state=114)

<img width="434" alt="Снимок экрана 2022-10-17 в 15 41 58" src="https://user-images.githubusercontent.com/37587023/196157653-7ded090c-9dd3-436c-b5ed-1fd8c0aac534.png">

### > Успешная [сборка](http://ios.teamcity.ti/viewLog.html?buildId=52779&buildTypeId=Mir_BuildIOS) проекта при отсутствии файла `api_key.json` и наличием переменной окружения

Для действия `match` и дальнейшей работы заполняется параметр `api_key` - [доказательство](http://ios.teamcity.ti/viewLog.html?buildId=52779&buildTypeId=Mir_BuildIOS&tab=buildLog&_focus=560#_state=114)

<img width="469" alt="Снимок экрана 2022-10-17 в 15 42 14" src="https://user-images.githubusercontent.com/37587023/196157688-92c29e0b-be90-4526-bf02-1d831d8a5380.png">

### Обе сборки в итоге успешно загружены в `AppStoreConnect`

<img width="1158" alt="Снимок экрана 2022-10-17 в 15 42 51" src="https://user-images.githubusercontent.com/37587023/196157813-c2c05796-091c-40bd-b5a0-645180404ab5.png">
