### PR TITLE
`default_options` empty initializer added for correct method running

### DIFF
--- a/xcode/commonFastfile
+++ b/xcode/commonFastfile
@@ -377,6 +377,10 @@ def fill_up_options_using_configuration_type(options, configuration_type)
   api_key_path = File.expand_path "../fastlane/#{configuration_type.prefix}_api_key.json"
   is_api_key_file_exists = File.exists?(api_key_path)
 
+  # default_options required to be empty due to the possibility of skipping the configuration type check below
+
+  default_options = {}
+
   # Check whether configuration type is required to configure one of api key parameters or not
 
   if configuration_type.is_app_store || configuration_type.is_development


### PR DESCRIPTION
## Исправление инициализации `default_options` в `commonFastfile`

- Если мы не зайдем в проверку конфигурации `.is_app_store || .is_development`, то переменная `default_options` будет равняться `nil`, из-за чего последующие команды `.merge` не пройдут и выполнение скрипта упадет. Исправил данную логику указанием начального значения

### Результат - сборка [#3725](http://ios.teamcity.ti/viewLog.html?buildId=52844&buildTypeId=Mir_BuildIOS&tab=buildResultsDiv)

<img width="451" alt="Снимок экрана 2022-10-18 в 20 47 47" src="https://user-images.githubusercontent.com/37587023/196479875-039b8ccd-b201-4421-9dcc-735d39784c11.png">