### PR TITLE
update BuildScripts to include copy task in AndroidLinter.kt

### DIFF
--- a/gradle/plugins/src/main/java/static_analysis/linters/AndroidLinter.kt
+++ b/gradle/plugins/src/main/java/static_analysis/linters/AndroidLinter.kt
@@ -48,11 +48,14 @@ class AndroidLinter : Linter {
                 .mapNotNull { subproject: Project ->
                     subproject
                             .tasks
-                            .find { task -> task.name.equals("lint$buildType", ignoreCase = true) }
-                            ?.path
+                            .filter { task ->
+                                task.name.equals("lint${buildType}", ignoreCase = true)
+                                        || task.name.equals("copy${buildType}AndroidLintReports", ignoreCase = true)
+                            }
+                            .map { it.path }
                 }
+                .flatten()
     }
 
     private fun Project.getLintReportFile() = file("${rootProject.buildDir}/reports/lint-report.xml")
-
 }


### PR DESCRIPTION
добавил вторую задачу для AndroidLinter без которой переход к задаче staticAnalysis вызывает ошибку из-за отсутствия отчета `lint-report.xml` в ожидаемой папке

это помогает сохранить порядок выполнения:
```
> Task :app:copyObfuscateCustomerDevWithoutSSLPinningWithoutTestPanelGoogleReleaseAndroidLintReports
Copying lint XML report to /opt/teamcity-buildagent/agent1/work/e1490a3cb9658cc/build/reports/lint-report.xml

> Task :staticAnalysisObfuscateCustomerDevWithoutSSLPinningWithoutTestPanelGoogleRelease
```